### PR TITLE
added occasions routes

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -2,6 +2,7 @@ from utils.config import IS_DEV
 
 import routes.bookings
 import routes.mediations
+import routes.occasions
 import routes.offers
 import routes.offerers
 import routes.providers

--- a/routes/occasions.py
+++ b/routes/occasions.py
@@ -1,0 +1,35 @@
+"""occasions"""
+from flask import current_app as app, jsonify
+from flask_login import current_user
+
+from utils.human_ids import dehumanize
+from utils.includes import OCCASION_INCLUDES
+from utils.rest import login_or_api_key_required
+from utils.string_processing import inflect_engine
+
+@app.route('/occasions', methods=['GET'])
+@login_or_api_key_required
+def list_occasions():
+    event_ids = []
+    occasions = []
+    for offerer in current_user.offerers:
+        for offer in offerer.offers:
+            occasion = None
+            if offer.eventOccurence and offer.eventOccurence.event.id not in event_ids:
+                event_ids.append(offer.eventOccurence.event.id)
+                occasion = offer.eventOccurence.event._asdict(include=OCCASION_INCLUDES)
+                occasion['occasionType'] = 'events'
+                occasions.append(occasion)
+            elif offer.thing:
+                occasion = offer.thing._asdict(include=OCCASION_INCLUDES)
+                occasion['occasionType'] = 'things'
+                occasions.append(occasion)
+    return jsonify(occasions)
+
+@app.route('/occasions/<occasionType>/<occasionId>', methods=['GET'])
+@login_or_api_key_required
+def get_occasion(occasionType, occasionId):
+    model_name = inflect_engine.singular_noun(occasionType.title(), 1)
+    occasion = app.model[model_name]\
+                  .query.filter_by(id=dehumanize(occasionId)).one()
+    return jsonify(occasion._asdict(include=OCCASION_INCLUDES))

--- a/routes/offers.py
+++ b/routes/offers.py
@@ -77,9 +77,9 @@ def list_offers():
                                 include=OFFERS_INCLUDES,
                                 paginate=50)
 
-
-@app.route('/offers/<offer_id>', methods=['GET'],
-                                 defaults={'mediation_id': None})
+@app.route('/offers/<offer_id>',
+           methods=['GET'],
+           defaults={'mediation_id': None})
 @app.route('/offers/<offer_id>/<mediation_id>', methods=['GET'])
 def get_offer(offer_id, mediation_id):
     query = make_offer_query().filter_by(id=dehumanize(offer_id))

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -1,3 +1,6 @@
+OCCASION_INCLUDES = [
+    'mediations'
+]
 
 OFFERS_INCLUDES = [
     {
@@ -30,7 +33,7 @@ OFFERS_INCLUDES = [
     "venue"
 ]
 
-RECOMMENDATIONS_INCLUDES =  [
+RECOMMENDATIONS_INCLUDES = [
     "mediatedOccurences",
     {
         "key": "mediation",
@@ -89,6 +92,7 @@ USERS_INCLUDES = [
 
 includes = {
     'bookings': BOOKINGS_INCLUDES,
+    'occasions': OCCASION_INCLUDES,
     'offerers': OFFERERS_INCLUDES,
     'offers': OFFERS_INCLUDES,
     'recommendations': RECOMMENDATIONS_INCLUDES,


### PR DESCRIPTION
occasions: c'est la route qui permet d'avoir tous les events/things de tous les offerers d'un user pro.

@arnoo 
on va merger mais ca serait bien d'optimiser encore plus la route occasions: car en gros, en parsant toutes les offers dans le code python pour recuperer les events associés, je fais à la main le fait de ne pas prendre deux fois le même events (car plusieurs offers pointent vers le meme events).

Or comme on a déjà offerers.offers dans la db en backref, on pourrait directement avoir offerers.events aussi et ca rendrait le code bcp plus performant.