### PR TITLE
Allow logger arguments to be lambda for lazy evaluation

### DIFF
--- a/datascience/occasions.py
+++ b/datascience/occasions.py
@@ -25,6 +25,8 @@ Venue = app.model.Venue
 
 log = app.log
 
+
+
 # --- SCORING ---
 
 
@@ -49,7 +51,7 @@ def make_score_tuples(occasions, departement_codes):
                                 else score_thing
     scored_occasions = list(map(lambda e: (e, sort_function(e, departement_codes)),
                                 occasions))
-    log.debug('(reco) scored occasions'+str([(se[0], se[1]) for se in scored_occasions]))
+    log.debug(lambda: '(reco) scored occasions'+str([(se[0], se[1]) for se in scored_occasions]))
     return scored_occasions
 
 
@@ -115,7 +117,7 @@ def departement_or_national_occasions(query, occasion_type, departement_codes):
                  .join(Venue)\
                  .filter(condition)\
                  .distinct(occasion_type.id)
-    log.debug('(reco) departement '+str(occasion_type)+'.count '+str(query.count()))
+    log.debug(lambda: '(reco) departement '+str(occasion_type)+'.count '+str(query.count()))
     return query
 
 
@@ -124,7 +126,7 @@ def bookable_occasions(query, occasion_type):
     # (crude filter to limit joins before the more complete one below)
     if occasion_type == Event:
         query = query.filter(Event.occurences.any(EventOccurence.beginningDatetime > datetime.utcnow()))
-        log.debug('(reco) future events.count '+str(query.count()))
+        log.debug(lambda: '(reco) future events.count '+str(query.count()))
         join_table = aliased_join_table(occasion_type)
         query = query.join(join_table)
 
@@ -137,7 +139,7 @@ def bookable_occasions(query, occasion_type):
                             (bo_Offer.available > Booking.query.filter(Booking.offerId == bo_Offer.id)
                                                          .statement.with_only_columns([func.coalesce(func.sum(Booking.quantity), 0)]))))\
                  .distinct(occasion_type.id)
-    log.debug('(reco) bookable '+str(occasion_type)+'.count '+str(query.count()))
+    log.debug(lambda: '(reco) bookable '+str(occasion_type)+'.count '+str(query.count()))
     return query
 
 
@@ -145,7 +147,7 @@ def with_active_and_validated_offerer(query, occasion_type):
     query = query.join(Offerer)\
                  .filter((Offerer.isActive == True)
                          & (Offerer.validationToken == None))
-    log.debug('(reco) from active and validated offerer '+str(occasion_type)+'.count'+str(query.count()))
+    log.debug(lambda: '(reco) from active and validated offerer '+str(occasion_type)+'.count'+str(query.count()))
     return query
 
 
@@ -154,7 +156,7 @@ def not_currently_recommended_occasions(query, occasion_type, user):
                                                                & (Recommendation.validUntilDate > datetime.utcnow())))
                             | (occasion_type.mediations.any(Mediation.recommendations.any((Recommendation.userId == user.id)
                                                                                           & (Recommendation.validUntilDate > datetime.utcnow()))))))
-    log.debug('(reco) not already used '+str(occasion_type)+'occasions.count '+str(query.count()))
+    log.debug(lambda: '(reco) not already used '+str(occasion_type)+'occasions.count '+str(query.count()))
     return query
 
 
@@ -169,7 +171,7 @@ def get_occasions_by_type(occasion_type,
     query = occasion_type.query
     if occasion_id is not None:
         query = query.filter_by(id=occasion_id)
-    log.debug('(reco) all '+str(occasion_type)+'.count '+str(query.count()))
+    log.debug(lambda: '(reco) all '+str(occasion_type)+'.count '+str(query.count()))
 
     query = departement_or_national_occasions(query, occasion_type, departement_codes)
     query = bookable_occasions(query, occasion_type)

--- a/tests/12_routes_recommendations.py
+++ b/tests/12_routes_recommendations.py
@@ -55,14 +55,17 @@ def subtest_recos_with_params(params,
                               expected_status=200,
                               expected_mediation_id=None,
                               expected_occasion_type=None,
-                              expected_occasion_id=None):
+                              expected_occasion_id=None,
+                              is_tuto=False):
     r = req_with_auth().put(RECOMMENDATION_URL+'?'+params, json={})
     assert r.status_code == expected_status
     if expected_status == 200:
         recos = r.json()
         assert len(recos) <= BLOB_SIZE + (2 if expected_mediation_id is None
                                             else 3)
-        assert recos[1]['mediation']['tutoIndex'] is not None
+        assert len(list(filter(lambda reco: 'mediation' in reco and
+                                            reco['mediation']['tutoIndex'] is not None,
+                               recos))) == (1 if is_tuto else 0)
         check_recos(recos)
         return recos
 
@@ -116,7 +119,8 @@ def test_13_requesting_a_reco_with_bad_params_should_return_reponse_anyway():
     # occasionId correct and mediationId correct but not the same event
     subtest_recos_with_params('occasionType=event&occasionId=AQ&mediationId=AE',
                               expected_status=200,
-                              expected_mediation_id=dehumanize('AE')) # FIRST TUTO MEDIATION
+                              expected_mediation_id=dehumanize('AE'),
+                              is_tuto=True) 
     # occasionId correct and mediationId correct but not the same occasion type
     subtest_recos_with_params('occasionType=event&occasionId=A9&mediationId=AM',
                               expected_status=200,

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,10 +1,31 @@
 from flask import current_app as app
 import logging
 
+from utils.attr_dict import AttrDict
 from utils.config import LOG_LEVEL
 
 logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
                     level=LOG_LEVEL,
                     datefmt='%Y-%m-%d %H:%M:%S')
 
-app.log = logging
+
+# this is so that we can have log.debug(XXX) calls in the app
+# without XXX being evaluated when not at debug level
+# this allows args to log.debug & co. to be lambdas that will
+# get called when the loglevel is right
+# cf. datascience/occasions, in which the data printed in
+# debug calls is costly to compute.
+def pc_logging(level, *args):
+    global logging
+    if logging.getLogger().isEnabledFor(level):
+        evaled_args = map(lambda a: a() if callable(a) else a,
+                          args)
+        logging.log(level, *evaled_args)
+
+
+app.log = AttrDict()
+app.log.critical = lambda *args: pc_logging(logging.CRITICAL, *args)
+app.log.debug = lambda *args: pc_logging(logging.DEBUG, *args)
+app.log.error = lambda *args: pc_logging(logging.ERROR, *args)
+app.log.info = lambda *args: pc_logging(logging.INFO, *args)
+app.log.warning = lambda *args: pc_logging(logging.WARNING, *args)


### PR DESCRIPTION
Les appels à log.debug ont beau ne rien logger en staging/production du fait que le "loglevel" est plus élevé que debug, pour pouvoir appeller log.debug, Python doit évaluer les arguments qu'on lui a passé. Dans le cas des "count" qu'on fait partout dans datascience/occasion, ça coute très cher (plein de requêtes intermédiaires).

Cette PR permet de passer à logger.debug & Co. des lambdas en lieu et place des arguments habituels (si on le souhaite), lambda qui seront évaluées seulement si nécessaire. Ça devrait bien améliorer la perf de /recommendations en prod.