### PR TITLE
added constraint user cannot book if admin. refactored raising except…

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from sqlalchemy.sql import expression
 from sqlalchemy.orm import relationship
-from sqlalchemy import Binary, Boolean, Column, DateTime, String, func
+from sqlalchemy import Binary, Boolean, Column, DateTime, String, func, CheckConstraint
 import bcrypt
 
 from models import Deposit, Booking
@@ -40,9 +40,13 @@ class User(PcObject,
                      default=True)
 
     isAdmin = Column(Boolean,
+                     CheckConstraint('("canBook" IS FALSE AND "isAdmin" IS TRUE)'
+                                     + 'OR ("isAdmin" IS FALSE)',
+                                     name='check_admin_cannot_book'),
                      nullable=False,
                      server_default=expression.false(),
-                     default=False)
+                     default=False,
+                     )
 
     def checkPassword(self, passwordToCheck):
         return bcrypt.hashpw(passwordToCheck.encode('utf-8'), self.password) == self.password

--- a/tests/16_routes_users.py
+++ b/tests/16_routes_users.py
@@ -327,3 +327,23 @@ def test_28_user_should_have_its_waller_balance(app):
     print('json', r_create.json())
     #Then
     assert wallet_balance == 15
+
+
+def test_29_user_with_isAdmin_true_and_canBook_raises_error():
+    user_json = {
+        'email': 'pctest.isAdmin.canBook@btmx.fr',
+        'publicName': 'IsAdmin CanBook',
+        'password': 'toto12345678',
+        'contact_ok': 'true',
+        'isAdmin': True,
+        'canBook': True
+    }
+    r_signup = req.post(API_URL + '/users',
+                                  json=user_json)
+    #print(r_signup)
+    #print(r_signup.json())
+    assert r_signup.status_code == 400
+    print(r_signup)
+    error = r_signup.json()
+    pprint(error)
+    assert error == {'canBook': ['Admin ne peut pas booker']}

--- a/tests/17_routes_bookings.py
+++ b/tests/17_routes_bookings.py
@@ -95,17 +95,38 @@ def test_14_create_booking_should_work_if_user_can_book():
     assert r_create.status_code == 201
 
 
-def test_15_create_booking_should_not_work_if_user_can_not_book():
+def test_15_create_booking_should_not_work_if_user_is_admin():
     # with default admin user
     booking_json = {
         'offerId': humanize(3),
         'recommendationId': humanize(1),
     }
     r_create = req_with_auth().post(API_URL + '/bookings', json=booking_json)
+    assert r_create.json()['canBook'] == ["L'utilisateur n'a pas le droit de réserver d'offre"]
     assert r_create.status_code == 400
 
 
-def test_16_create_booking_should_not_work_if_not_enough_credit(app):
+def test_16_create_booking_should_not_work_if_user_can_not_book(app):
+    # Given
+    user = User()
+    user.publicName = 'Cannot Book'
+    user.email = 'user_cannot_book@email.com'
+    user.setPassword('testpsswd')
+    user.departementCode = '93'
+    user.canBook = False
+    PcObject.check_and_save(user)
+
+    booking_json = {
+        'offerId': humanize(3),
+        'recommendationId': humanize(1),
+    }
+    r_create = req_with_auth().post(API_URL + '/bookings', json=booking_json)
+    print(r_create.json())
+    assert r_create.json()['canBook'] == ["L'utilisateur n'a pas le droit de réserver d'offre"]
+    assert r_create.status_code == 400
+
+
+def test_17_create_booking_should_not_work_if_not_enough_credit(app):
     #Given
     user = User()
     user.publicName = 'Test'

--- a/tests/22_models_users.py
+++ b/tests/22_models_users.py
@@ -1,0 +1,19 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models import User, PcObject
+
+
+def test_01_cannot_create_admin_that_can_book(app):
+    #Given
+    user = User()
+    user.publicName = 'Admin CanBook'
+    user.email = 'admin_can_book@email.com'
+    user.setPassword('testpsswd')
+    user.departementCode = '93'
+    user.isAdmin = True
+    user.canBook = True
+
+    #When
+    with pytest.raises(IntegrityError):
+        PcObject.check_and_save(user)


### PR DESCRIPTION
- Ajout d'une contrainte db : un admin ne peut pas booker
- Refactoré exceptions api
-  tests routes users et models user
- Test instable : 16_routes_user::test_27_pro_signup_with_existing_offerer : il trouve parfois un email dans la base qui n'existe pas et pète le test. Le test marche avec en mettant User.query.filter_by(email=new_user.email).count() avant la ligne 169 dans routes/users