### PR TITLE
Fix migration for booking.amount and thingId/eventId

### DIFF
--- a/alembic/versions/1ccdca2e1e6e_add_amount_to_booking.py
+++ b/alembic/versions/1ccdca2e1e6e_add_amount_to_booking.py
@@ -18,6 +18,7 @@ def upgrade():
     op.execute(
         'ALTER TABLE "booking" ADD COLUMN amount numeric(10,2);'
         'UPDATE booking b SET amount=(SELECT o.price FROM offer o WHERE o.id=b."offerId");'
+        'DELETE FROM booking WHERE "offerId" IS NULL;'
         'ALTER TABLE "booking" ALTER COLUMN "amount" SET NOT NULL;'
         'ALTER TABLE "booking" ALTER COLUMN "offerId" SET NOT NULL;'
     )

--- a/alembic/versions/e8c43e6dc0d8_only_occasion_has_thingId_or_eventId.py
+++ b/alembic/versions/e8c43e6dc0d8_only_occasion_has_thingId_or_eventId.py
@@ -56,6 +56,26 @@ def upgrade():
         ')'
     )
 
+    op.execute(
+        'UPDATE mediation m '
+        'SET "occasionId" = ('
+        '   SELECT o.id'
+        '   FROM occasion o'
+        '   WHERE m."eventId" = o."eventId"'
+        '   LIMIT 1'
+        ')'
+    )
+
+    op.execute(
+        'UPDATE recommendation r '
+        'SET "occasionId" = ('
+        '   SELECT m."occasionId"'
+        '   FROM mediation m'
+        '   WHERE r."eventId" = m."eventId"'
+        '   LIMIT 1'
+        ')'
+    )
+
     op.alter_column('event_occurence', 'occasionId', existing_type=sa.BigInteger(), nullable=False)
     op.alter_column('thing', 'type', existing_type=sa.VARCHAR(length=50), nullable=False)
 


### PR DESCRIPTION
Corrige deux problèmes sur les migrations. Comme on ne les a pas encore jouées sur les serveurs, pas besoin de faire une migration corrective, on peut encore les modifier.

- à cause d'un bug, un booking avait un offerId NULL sur la base de prod. On ne peut rien en faire et la migration s'étouffait dessus → drop. On a bien ajouté la contrainte NOT NULL sur la colonne, ça n'arrivera plus.
- La migration qui remplace thingId/eventId par occasionId ne remplissait pas toutes les colonnes occasionId qu'elle créait : ça manquait dans mediation et dans recommendation.