### PR TITLE
118 info user in validation email

### DIFF
--- a/routes/offerers.py
+++ b/routes/offerers.py
@@ -54,7 +54,7 @@ def create_offerer():
         user_offerer = offerer.give_rights(current_user,
                                            RightsType.admin)
         PcObject.check_and_save(offerer, user_offerer)
-    maybe_send_offerer_validation_email(offerer)
+    maybe_send_offerer_validation_email(offerer, user_offerer)
     return jsonify(offerer._asdict(include=OFFERER_INCLUDES)), 201
 
 

--- a/templates/validation_email.html
+++ b/templates/validation_email.html
@@ -3,9 +3,12 @@
         <h1>Inscription ou rattachement PRO à valider</h1>
         <hr/>
         <div class="user_offerer">
-            <h2>Nouveau Rattachement :</h2>
 
-            {% if not user_offerer.isValidated %}
+            {% if user_offerer.isValidated %}
+            <h2>Rattachement :</h2>
+            {% else %}
+            <h2>Nouveau rattachement :</h2>
+
             <strong class="validation">
                 Pour valider, <a href="{{ api_url }}/validate?modelNames=UserOfferer&token={{ user_offerer.validationToken }}">cliquez ici</a>
             </strong>
@@ -18,9 +21,10 @@
         </div>
         <hr/>
         <div class="offerer">
-            <h2>Nouvelle Structure :</h2>
-
-            {% if not offerer.isValidated %}
+            {% if offerer.isValidated %}
+            <h2>Structure :</h2>
+            {% else %}
+            <h2>Nouvelle structure :</h2>
             <strong class="validation">
                 Pour valider, <a href="{{ api_url }}/validate?modelNames=Offerer&token={{ offerer.validationToken }}">cliquez ici</a>
             </strong>

--- a/templates/validation_email.html
+++ b/templates/validation_email.html
@@ -1,28 +1,34 @@
 <html>
     <body>
         <h1>Inscription ou rattachement PRO à valider</h1>
-
+        <hr/>
         <div class="user_offerer">
             <h2>Nouveau Rattachement :</h2>
+
+            {% if not user_offerer.isValidated %}
+            <strong class="validation">
+                Pour valider, <a href="{{ api_url }}/validate?modelNames=UserOfferer&token={{ user_offerer.validationToken }}">cliquez ici</a>
+            </strong>
+            {% endif %}
+
             <h3>Utilisateur :</h3>
             <pre>{{ user_vars }}</pre>
             <h4>Structure :</h4>
             <pre>{{ offerer_vars_user_offerer }} </pre>
-
-            <strong>
-                Pour valider, <a href="{{ api_url }}/validate?modelNames=UserOfferer&token={{ user_token }}">cliquez ici</a>
-            </strong>
         </div>
-
+        <hr/>
         <div class="offerer">
             <h2>Nouvelle Structure :</h2>
+
+            {% if not offerer.isValidated %}
+            <strong class="validation">
+                Pour valider, <a href="{{ api_url }}/validate?modelNames=Offerer&token={{ offerer.validationToken }}">cliquez ici</a>
+            </strong>
+            {% endif %}
+
             <pre class="offerer-data">{{ offerer_vars }}</pre>
             <h3>Infos API entreprise :</h3>
             <pre class="api-entreprise-data">{{ api_entreprise }}</pre>
-
-            <strong>
-                Pour valider, <a href="{{ api_url }}/validate?modelNames=Offerer&token={{ offerer_token }}">cliquez ici</a>
-            </strong>
         </div>
     </body>
 </html>

--- a/templates/validation_email.html
+++ b/templates/validation_email.html
@@ -1,19 +1,28 @@
 <html>
     <body>
-        <p>Inscription ou rattachement PRO à valider</p>
-        {% for users_vars, offerers_vars in users_offerers_vars %}
-        <h3 class='user_offerer'>Nouveau Rattachement : </h3>
-        <h4 class='user_offerer'>Utilisateur: </h4>
-        <pre class='user_offerer'>{{ users_vars }}</pre>
-        <h4 class='user_offerer'>Structure: </h4>
-        <pre class='user_offerer'>{{ offerers_vars}} </pre>
-        {% endfor %}
-        {% for offerers_vars, api_data in offerer_information %}
-        <h3 class='offerer'>Nouvelle Structure : </h3>
-        <pre class='offerer'>{{ offerers_vars }}</pre>
-        <h4 class='offerer'>Infos API entreprise : </h4>
-        <pre class='offerer'>{{ api_data }}</pre>
-        {% endfor %}
-        Pour valider, <a href='{{ api_url }}/validate?modelNames={{ joined_classes_to_validate }}&token={{ token }}'>cliquez ici</a>
+        <h1>Inscription ou rattachement PRO à valider</h1>
+
+        <div class="user_offerer">
+            <h2>Nouveau Rattachement :</h2>
+            <h3>Utilisateur :</h3>
+            <pre>{{ user_vars }}</pre>
+            <h4>Structure :</h4>
+            <pre>{{ offerer_vars_user_offerer }} </pre>
+
+            <strong>
+                Pour valider, <a href="{{ api_url }}/validate?modelNames=UserOfferer&token={{ user_token }}">cliquez ici</a>
+            </strong>
+        </div>
+
+        <div class="offerer">
+            <h2>Nouvelle Structure :</h2>
+            <pre class="offerer-data">{{ offerer_vars }}</pre>
+            <h3>Infos API entreprise :</h3>
+            <pre class="api-entreprise-data">{{ api_entreprise }}</pre>
+
+            <strong>
+                Pour valider, <a href="{{ api_url }}/validate?modelNames=Offerer&token={{ offerer_token }}">cliquez ici</a>
+            </strong>
+        </div>
     </body>
 </html>

--- a/tests/utils_mailing_test.py
+++ b/tests/utils_mailing_test.py
@@ -1,17 +1,14 @@
 import secrets
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from bs4 import BeautifulSoup
 
-from connectors.api_entreprises import ApiEntrepriseException
-from models import Offerer, UserOfferer, User
 from tests.conftest import clean_database
 from utils.config import IS_DEV, IS_STAGING, ENV
 from utils.mailing import make_user_booking_recap_email, send_booking_confirmation_email_to_user, \
     make_booking_recap_email, make_final_recap_email_for_stock_with_event, write_object_validation_email, \
     maybe_send_offerer_validation_email, MailServiceException
-
 from utils.test_utils import create_stock_with_event_offer, create_stock_with_thing_offer, \
     create_user, create_booking, MOCKED_SIREN_ENTREPRISES_API_RETURN, create_user_offerer, \
     create_offerer, create_venue, create_thing_offer
@@ -25,7 +22,6 @@ def get_mocked_response_status_200(entity):
 
 SUBJECT_USER_EVENT_BOOKING_CONFIRMATION_EMAIL = \
     'Confirmation de votre réservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00'
-
 
 HTML_USER_BOOKING_EVENT_CONFIRMATION_EMAIL = \
 '''<html>
@@ -48,40 +44,40 @@ SUBJECT_USER_THING_BOOKING_CONFIRMATION_EMAIL = \
     'Confirmation de votre commande pour Test Book'
 
 HTML_USER_BOOKING_THING_CONFIRMATION_EMAIL = '<html><body>' + \
-           '<p id="mail-greeting">Cher Test,</p>' + \
-           '<div id="mail-content">Nous vous confirmons votre commande pour Test Book (Ref: 12345),' + \
-           ' proposé par Test offerer.' + \
-           ' Votre code de réservation est le 56789.</div>' + \
-           '<p id="mail-salutation">Cordialement,' + \
-           '<br>L\'équipe pass culture</p>' + \
-           '</body></html>'
+                                             '<p id="mail-greeting">Cher Test,</p>' + \
+                                             '<div id="mail-content">Nous vous confirmons votre commande pour Test Book (Ref: 12345),' + \
+                                             ' proposé par Test offerer.' + \
+                                             ' Votre code de réservation est le 56789.</div>' + \
+                                             '<p id="mail-salutation">Cordialement,' + \
+                                             '<br>L\'équipe pass culture</p>' + \
+                                             '</body></html>'
 
 SUBJECT_USER_BOOKING_THING_CANCELLATION_EMAIL = \
     'Annulation de votre commande pour Test Book'
 
 HTML_USER_BOOKING_THING_CANCELLATION_EMAIL = '<html><body>' + \
-           '<p id="mail-greeting">Cher Test,</p>' + \
-           '<div id="mail-content">Votre commande pour Test Book (Ref: 12345), ' + \
-           'proposé par Test offerer ' + \
-           'a bien été annulée.</div>' + \
-           '<p id="mail-salutation">Cordialement,' + \
-           '<br>L\'équipe pass culture</p>' + \
-           '</body></html>'
+                                             '<p id="mail-greeting">Cher Test,</p>' + \
+                                             '<div id="mail-content">Votre commande pour Test Book (Ref: 12345), ' + \
+                                             'proposé par Test offerer ' + \
+                                             'a bien été annulée.</div>' + \
+                                             '<p id="mail-salutation">Cordialement,' + \
+                                             '<br>L\'équipe pass culture</p>' + \
+                                             '</body></html>'
 
 SUBJECT_USER_BOOKING_EVENT_CANCELLATION_EMAIL = \
     'Annulation de votre réservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00'
 
 HTML_USER_BOOKING_EVENT_CANCELLATION_EMAIL = '<html><body>' + \
-           '<p id="mail-greeting">Cher Test,</p>' + \
-           '<div id="mail-content">Votre réservation pour Mains, sorts et papiers, ' + \
-           'proposé par Test offerer ' + \
-           'le 20 juillet 2019 à 14:00, ' + \
-           'a bien été annulée.</div>' + \
-           '<p id="mail-salutation">Cordialement,' + \
-           '<br>L\'équipe pass culture</p>' + \
-           '</body></html>'
+                                             '<p id="mail-greeting">Cher Test,</p>' + \
+                                             '<div id="mail-content">Votre réservation pour Mains, sorts et papiers, ' + \
+                                             'proposé par Test offerer ' + \
+                                             'le 20 juillet 2019 à 14:00, ' + \
+                                             'a bien été annulée.</div>' + \
+                                             '<p id="mail-salutation">Cordialement,' + \
+                                             '<br>L\'équipe pass culture</p>' + \
+                                             '</body></html>'
 
-SUBJECT_OFFERER_BOOKING_CONFIRMATION_EMAIL =\
+SUBJECT_OFFERER_BOOKING_CONFIRMATION_EMAIL = \
     '[Reservations] Nouvelle reservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00'
 HTML_OFFERER_BOOKING_CONFIRMATION_EMAIL = \
     '<html><body>' + \
@@ -90,8 +86,8 @@ HTML_OFFERER_BOOKING_CONFIRMATION_EMAIL = \
     '<p>Voici le récapitulatif des réservations à ce jour (total 1)' + \
     ' pour Mains, sorts et papiers le 20 juillet 2019 à 14:00,' + \
     ' proposé par Test offerer (Adresse : 123 rue test, 93000 Test city).</p>' + \
-    '<table><tr><th>Nom ou pseudo</th><th>Email</th><th>Code réservation</th></tr>' +\
-    '<tr><td>Test</td><td>test@email.com</td><td>56789</td></tr></table>' +\
+    '<table><tr><th>Nom ou pseudo</th><th>Email</th><th>Code réservation</th></tr>' + \
+    '<tr><td>Test</td><td>test@email.com</td><td>56789</td></tr></table>' + \
     '</body></html>'
 
 
@@ -106,6 +102,7 @@ def test_make_user_booking_event_recap_email_should_have_standard_subject(app):
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=False)
+
     # Then
     assert recap_email['Subject'] == SUBJECT_USER_EVENT_BOOKING_CONFIRMATION_EMAIL
 
@@ -123,9 +120,9 @@ def test_make_user_booking_event_recap_email_should_have_standard_body(app):
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=False)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_email_soup.prettify()
 
 
@@ -140,6 +137,7 @@ def test_make_user_booking_event_recap_email_should_have_standard_subject_cancel
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=True)
+
     # Then
     assert recap_email['Subject'] == SUBJECT_USER_BOOKING_EVENT_CANCELLATION_EMAIL
 
@@ -155,13 +153,11 @@ def test_make_user_booking_event_recap_email_should_have_standard_body_cancellat
     booking = create_booking(user, stock, venue, None)
     expected_email_soup = BeautifulSoup(HTML_USER_BOOKING_EVENT_CANCELLATION_EMAIL, 'html.parser')
 
-
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=True)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
-    print(user.publicName)
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_email_soup.prettify()
 
 
@@ -187,11 +183,11 @@ def test_send_booking_confirmation_email_to_user_should_call_mailjet_send_create
         recipients = 'test@email.com'
 
     expected_email = {
-      "FromName": 'Pass Culture',
-      'FromEmail': 'passculture-dev@beta.gouv.fr',
-      'To': recipients,
-      'Subject': SUBJECT_USER_EVENT_BOOKING_CONFIRMATION_EMAIL,
-      'Html-part': mail_html
+        "FromName": 'Pass Culture',
+        'FromEmail': 'passculture-dev@beta.gouv.fr',
+        'To': recipients,
+        'Subject': SUBJECT_USER_EVENT_BOOKING_CONFIRMATION_EMAIL,
+        'Html-part': mail_html
     }
 
     app.mailjet_client.send.create.return_value = Mock(status_code=200)
@@ -206,7 +202,7 @@ def test_send_booking_confirmation_email_to_user_should_call_mailjet_send_create
 @clean_database
 @pytest.mark.standalone
 def test_maker_user_booking_thing_recap_email_should_have_standard_body(app):
-    #Given
+    # Given
     venue = create_venue(None, 'Test offerer', 'reservations@test.fr', '123 rue test', '93000', 'Test city', '93')
     thing_offer = create_thing_offer(venue=None)
     stock = create_stock_with_thing_offer(offerer=None, venue=venue, thing_offer=thing_offer)
@@ -218,9 +214,9 @@ def test_maker_user_booking_thing_recap_email_should_have_standard_body(app):
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=False)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_email_soup.prettify()
 
 
@@ -237,6 +233,7 @@ def test_maker_user_booking_thing_recap_email_should_have_standard_subject(app):
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=False)
+
     # Then
     assert recap_email['Subject'] == SUBJECT_USER_THING_BOOKING_CONFIRMATION_EMAIL
 
@@ -254,6 +251,7 @@ def test_make_user_booking_thing_recap_email_should_have_standard_subject_cancel
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=True)
+
     # Then
     assert recap_email['Subject'] == SUBJECT_USER_BOOKING_THING_CANCELLATION_EMAIL
 
@@ -272,9 +270,9 @@ def test_make_user_booking_thing_recap_email_should_have_standard_body_cancellat
 
     # When
     recap_email = make_user_booking_recap_email(booking, is_cancellation=True)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_email_soup.prettify()
 
 
@@ -292,10 +290,9 @@ def test_booking_recap_email_html_should_have_place_and_structure(app):
 
     # When
     recap_email = make_booking_recap_email(stock, booking)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
-    print(recap_email_soup.prettify())
     # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_email_soup.prettify()
 
 
@@ -326,16 +323,17 @@ def test_offerer_recap_email_subject_past_offer_without_booking(app):
                                           venue=venue,
                                           beginning_datetime_future=False)
 
-    #When
+    # When
     recap_email = make_final_recap_email_for_stock_with_event(stock)
 
+    # Then
     assert recap_email['Subject'] == expected_subject
 
 
 @clean_database
 @pytest.mark.standalone
 def test_offerer_recap_email_past_offer_without_booking(app):
-    #Given
+    # Given
     expected_html = '''
         <html>
             <body>
@@ -353,11 +351,11 @@ def test_offerer_recap_email_past_offer_without_booking(app):
                                           venue=venue,
                                           beginning_datetime_future=False)
 
-    #When
+    # When
     recap_email = make_final_recap_email_for_stock_with_event(stock)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
-    #Then
+    # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert expected_html_soup.prettify() == recap_email_soup.prettify()
 
 
@@ -398,9 +396,9 @@ def test_offerer_recap_email_past_offer_with_booking(app):
 
     # When
     recap_email = make_final_recap_email_for_stock_with_event(offer)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_html_soup.prettify()
 
 
@@ -452,10 +450,9 @@ def test_offerer_recap_email_future_offer_when_new_booking_with_old_booking(app)
 
     # When
     recap_email = make_booking_recap_email(stock, booking_2)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
-    print(recap_email_soup.prettify() )
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_html_soup.prettify()
 
 
@@ -498,10 +495,9 @@ def test_offerer_booking_recap_email_book(app):
 
     # When
     recap_email = make_booking_recap_email(stock, booking)
-    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
 
     # Then
-    print(recap_email_soup.prettify())
+    recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
     assert recap_email_soup.prettify() == expected_html_soup.prettify()
 
 
@@ -523,29 +519,23 @@ def test_write_object_validation_email_should_have_some_specific_information(app
 
     # Then
     email_html_soup = BeautifulSoup(email['Html-part'], features="html.parser")
-    all_paragraphs = email_html_soup.find_all('p')
-    all_h3_user_offerer = email_html_soup.find_all('h3', "user_offerer")
-    all_pre_user_offerer = email_html_soup.find_all('pre', "user_offerer")
-    all_h4_user_offerer = email_html_soup.find_all('h4', "user_offerer")
-    all_a = email_html_soup.find_all('a')
-    all_h3_offerer = email_html_soup.find_all('h3', "offerer")
     all_pre_offerer = email_html_soup.find_all('pre', "offerer")
-    all_h4_offerer = email_html_soup.find_all('h4', "offerer")
-    assert str(all_paragraphs[0]) == '<p>Inscription ou rattachement PRO à valider</p>'
-    assert str(all_h3_offerer[0]) == '<h3 class="offerer">Nouvelle Structure : </h3>'
-    assert str(all_h3_user_offerer[0]) == '<h3 class="user_offerer">Nouveau Rattachement : </h3>'
-    assert str(all_h4_user_offerer[0]) == '<h4 class="user_offerer">Utilisateur: </h4>'
-    assert 'UserOfferers' in str(all_pre_user_offerer[0])
+    assert str(email_html_soup.find_all('p')[0]) == '<p>Inscription ou rattachement PRO à valider</p>'
+    assert str(email_html_soup.find_all('h3', "offerer")[0]) == '<h3 class="offerer">Nouvelle Structure : </h3>'
+    assert str(
+        email_html_soup.find_all('h3', "user_offerer")[0]) == '<h3 class="user_offerer">Nouveau Rattachement : </h3>'
+    assert str(email_html_soup.find_all('h4', "user_offerer")[0]) == '<h4 class="user_offerer">Utilisateur: </h4>'
+    assert 'UserOfferers' in str(email_html_soup.find_all('pre', "user_offerer")[0])
     assert "'address': '122 AVENUE DE FRANCE'" in str(all_pre_offerer[0])
     assert "'city': 'Paris'" in str(all_pre_offerer[0])
     assert "'name': 'Accenture'" in str(all_pre_offerer[0])
     assert "'postalCode': '75013'" in str(all_pre_offerer[0])
     assert "'siren': '732075312'" in str(all_pre_offerer[0])
     assert "'validationToken': '{}'".format(validation_token) in str(all_pre_offerer[0])
-    assert str(all_h4_offerer[0]) == '<h4 class="offerer">Infos API entreprise : </h4>'
+    assert str(email_html_soup.find_all('h4', "offerer")[0]) == '<h4 class="offerer">Infos API entreprise : </h4>'
     assert "'numero_tva_intra': 'FR60732075312'" in str(all_pre_offerer[1])
     assert '<a href="localhost/validate?modelNames=Offerer,UserOfferer&amp;token={}">cliquez ici</a>'.format(
-        validation_token) in str(all_a[0])
+        validation_token) in str(email_html_soup.find_all('a')[0])
     assert "'other_etablissements_sirets': ['73207531200213', '73207531200197', '73207531200171']".replace(
         ' ', '').replace('\n', '') in str(all_pre_offerer[1]).replace(' ', '').replace('\n', '')
     assert 'siege_social' in str(all_pre_offerer[1])
@@ -553,7 +543,7 @@ def test_write_object_validation_email_should_have_some_specific_information(app
 
 @clean_database
 @pytest.mark.standalone
-def test_write_object_validation_email_raises_value_error_when_object_to_validate_not_offerer_or_userOfferer(app):
+def test_write_object_validation_email_raises_value_error_when_object_to_validate_not_offerer_or_user_offerer(app):
     # Given
     validation_token = secrets.token_urlsafe(20)
 
@@ -578,10 +568,10 @@ def test_maybe_send_offerer_validation_email_does_not_send_email_if_all_validate
 
     user_offerer = create_user_offerer(user, offerer, validation_token=None)
 
-    #When
+    # When
     maybe_send_offerer_validation_email(offerer, user_offerer)
 
-    #Then
+    # Then
     assert not app.mailjet_client.send.create.called
 
 
@@ -601,7 +591,7 @@ def test_maybe_send_offerer_validation_email_raises_exception_if_status_code_400
 
     app.mailjet_client.send.create.return_value = Mock(status_code=400)
 
-    #When
+    # When
     with pytest.raises(MailServiceException):
         maybe_send_offerer_validation_email(offerer, user_offerer)
 
@@ -629,27 +619,3 @@ def test_validation_email_should_not_return_clearTextPassword(app):
     assert 'clearTextPassword' not in str(email_html_soup)
     assert 'totallysafepsswd' not in str(email_html_soup)
 
-
-# def test_16_offerer_recap_email_future_offer_when_cancellation_with_one_booking(app):
-#     # Given
-#     expected_html = '''
-#         <html>
-#             <body>
-#                 <p>Cher partenaire Pass Culture,</p
-#                 <p>Test (test@email.com) vient d'annuler sa réservation</p>
-#                 <p>Voici le récapitulatif final des réservations (total 2) pour Mains, sorts et papiers le 1 août 2018 à 10:58, proposé par Test offerer (Adresse : 123 rue test, 93000 Test city).
-#                 </p>
-#                 <p>Aucune réservation</p>
-#             </body>
-#         </html>'''
-#     expected_html_soup = BeautifulSoup(expected_html, 'html.parser')
-#     stock = create_stock_with_event_offer(beginning_datetime_future=True)
-#     user = create_user_for_booking_email_test()
-#     booking = create_booking_for_booking_email_test(user, stock, is_cancellation=True)
-#
-#     # When
-#     recap_email = make_booking_recap_email(stock, booking, is_cancellation=True)
-#     recap_email_soup = BeautifulSoup(recap_email['Html-part'], 'html.parser')
-#
-#     # Then
-#     assert recap_email_soup.prettify() == expected_html_soup.prettify()

--- a/tests/utils_mailing_test.py
+++ b/tests/utils_mailing_test.py
@@ -24,21 +24,21 @@ SUBJECT_USER_EVENT_BOOKING_CONFIRMATION_EMAIL = \
     'Confirmation de votre réservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00'
 
 HTML_USER_BOOKING_EVENT_CONFIRMATION_EMAIL = \
-    '''<html>
-        <body>
-            <p id="mail-greeting">Cher Test,</p>
-    
-            <div id="mail-content">
-                Nous vous confirmons votre réservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00, proposé par Test offerer (Adresse : 123 rue test, 93000 Test city). Votre code de réservation est le 56789.
-            </div>
-    
-            <p id="mail-salutation">
-                Cordialement,
-                <br>L\'équipe pass culture
-            </p>
-    
-        </body>
-    </html>'''
+'''<html>
+    <body>
+        <p id="mail-greeting">Cher Test,</p>
+
+        <div id="mail-content">
+            Nous vous confirmons votre réservation pour Mains, sorts et papiers le 20 juillet 2019 à 14:00, proposé par Test offerer (Adresse : 123 rue test, 93000 Test city). Votre code de réservation est le 56789.
+        </div>
+
+        <p id="mail-salutation">
+            Cordialement,
+            <br>L\'équipe pass culture
+        </p>
+
+    </body>
+</html>'''
 
 SUBJECT_USER_THING_BOOKING_CONFIRMATION_EMAIL = \
     'Confirmation de votre commande pour Test Book'

--- a/tests/utils_mailing_test.py
+++ b/tests/utils_mailing_test.py
@@ -522,13 +522,13 @@ def test_write_object_validation_email_should_have_some_specific_information(app
     assert html.h1.text == 'Inscription ou rattachement PRO à valider'
 
     div_offerer = html.select('div.offerer')[0]
-    assert div_offerer.h2.text == 'Nouvelle Structure :'
+    assert div_offerer.h2.text == 'Nouvelle structure :'
     assert div_offerer.h3.text == 'Infos API entreprise :'
     assert div_offerer.strong.a['href'] == 'localhost/validate?modelNames=Offerer&token={}'.format(offerer.validationToken)
     assert div_offerer.strong.a.text == 'cliquez ici'
 
     div_user_offerer = html.select('div.user_offerer')[0]
-    assert div_user_offerer.h2.text == 'Nouveau Rattachement :'
+    assert div_user_offerer.h2.text == 'Nouveau rattachement :'
     assert div_user_offerer.h3.text == 'Utilisateur :'
     assert div_user_offerer.strong.a['href'] == 'localhost/validate?modelNames=UserOfferer&token={}'.format(user_offerer.validationToken)
     assert div_user_offerer.strong.a.text == 'cliquez ici'
@@ -566,6 +566,7 @@ def test_write_object_validation_email_does_not_include_validation_link_if_user_
     # Then
     html = BeautifulSoup(email['Html-part'], features="html.parser")
     assert not html.select('div.user_offerer strong.validation a')
+    assert html.select('div.user_offerer h2')[0].text == 'Rattachement :'
 
 
 @clean_database
@@ -587,6 +588,7 @@ def test_write_object_validation_email_does_not_include_validation_link_if_offer
     # Then
     html = BeautifulSoup(email['Html-part'], features="html.parser")
     assert not html.select('div.offerer strong.validation a')
+    assert html.select('div.offerer h2')[0].text == 'Structure :'
 
 
 @clean_database

--- a/tests/utils_string_processing_test.py
+++ b/tests/utils_string_processing_test.py
@@ -1,16 +1,18 @@
+import pytest
 from hypothesis import given
 from hypothesis.strategies import text
 
 from utils.string_processing import get_matched_string_index, get_price_value
 
 
+@pytest.mark.standalone
 def test_get_matched_string_index():
     assert get_matched_string_index(
         'karl marx',
         ['henri guillemin', 'groucho marx', 'kroutchev', 'emmanuel macron']
     ) == 1
 
-
+@pytest.mark.standalone
 @given(string_value=text())
 def test_get_price_value(string_value, capsys):
     assert type(get_price_value(string_value)) == int

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -179,14 +179,12 @@ def write_object_validation_email(*objects_to_validate, get_by_siren=api_entrepr
 
     token = obj.validationToken
 
-
     email_html = render_template('validation_email.html',
                                  users_offerers_vars=zip(users_vars_user_offerer, offerers_vars_user_offerer),
                                  offerer_information=zip(offerers_vars_offerer, offerers_api),
                                  api_url=API_URL,
                                  joined_classes_to_validate=",".join(classes_to_validate),
                                  token=token)
-
 
     return {
         'FromName': 'Pass Culture',
@@ -203,6 +201,7 @@ def maybe_send_offerer_validation_email(*objects_to_validate):
     if len(unvalidated_objects) == 0:
         return
     email = write_object_validation_email(*unvalidated_objects)
+    print(app.mailjet_client.send)
     mailjet_result = app.mailjet_client.send.create(data=email)
     if mailjet_result.status_code != 200:
         raise MailServiceException("Email send failed: " + pformat(vars(mailjet_result)))

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -149,18 +149,15 @@ def make_booking_recap_email(stock, booking):
 def write_object_validation_email(offerer, user_offerer, get_by_siren=api_entreprises.get_by_siren):
     vars_obj_user = vars(user_offerer.user)
     vars_obj_user.pop('clearTextPassword', None)
-    user_vars = pformat(vars_obj_user)
-    offerer_vars_user_offerer = pformat(vars(user_offerer.offerer))
-    offerer_vars = pformat(vars(offerer))
     api_entreprise = get_by_siren(offerer).json()
 
     email_html = render_template('validation_email.html',
-                                 user_vars=user_vars,
-                                 offerer_vars_user_offerer=offerer_vars_user_offerer,
-                                 offerer_vars=offerer_vars,
+                                 user_offerer=user_offerer,
+                                 user_vars=pformat(vars_obj_user),
+                                 offerer=offerer,
+                                 offerer_vars_user_offerer=pformat(vars(user_offerer.offerer)),
+                                 offerer_vars=pformat(vars(offerer)),
                                  api_entreprise=api_entreprise,
-                                 user_token=user_offerer.validationToken,
-                                 offerer_token=offerer.validationToken,
                                  api_url=API_URL)
 
     return {

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -7,9 +7,7 @@ from pprint import pformat
 from flask import current_app as app, render_template
 
 from connectors import api_entreprises
-from models.offerer import Offerer
 from models.pc_object import PcObject
-from models.user_offerer import UserOfferer
 from utils.config import API_URL, ENV, IS_DEV, IS_STAGING
 from utils.date import format_datetime, utc_datetime_to_dept_timezone
 
@@ -175,12 +173,7 @@ def write_object_validation_email(offerer, user_offerer, get_by_siren=api_entrep
 
 
 def maybe_send_offerer_validation_email(offerer, user_offerer):
-    unvalidated_objects = []
-    if not offerer.isValidated:
-        unvalidated_objects.append(offerer)
-    if not user_offerer.isValidated:
-        unvalidated_objects.append(user_offerer)
-    if len(unvalidated_objects) == 0:
+    if offerer.isValidated and user_offerer.isValidated:
         return
     email = write_object_validation_email(offerer, user_offerer)
     mailjet_result = app.mailjet_client.send.create(data=email)

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -157,7 +157,7 @@ def write_object_validation_email(offerer, user_offerer, get_by_siren=api_entrep
                                  offerer=offerer,
                                  offerer_vars_user_offerer=pformat(vars(user_offerer.offerer)),
                                  offerer_vars=pformat(vars(offerer)),
-                                 api_entreprise=api_entreprise,
+                                 api_entreprise=pformat(api_entreprise),
                                  api_url=API_URL)
 
     return {


### PR DESCRIPTION
Dans le mail de validation envoyé à la création ou au rattachement d'une structure, les informations utilisateur ne sont actuellement renvoyées que pour les rattachements (validation d'un UserOfferer). Il faut les renvoyer aussi pour les créations (valdation d'un Offerer).