### PR TITLE
added reset routes

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -12,6 +12,7 @@ import routes.providers
 import routes.recommendations
 # TODO
 # if IS_DEV:
+import routes.reset
 import routes.storage
 import routes.things
 import routes.types

--- a/routes/reset.py
+++ b/routes/reset.py
@@ -1,0 +1,54 @@
+""" reset """
+from inspect import isclass
+from flask import current_app as app, jsonify, request
+
+import models
+from models.api_errors import ApiErrors
+from models.db import db
+from models.pc_object import PcObject
+
+RESET_TOKEN = os.environ.get('RESET_TOKEN')
+
+def check_token():
+    if RESET_TOKEN is None or RESET_TOKEN == '':
+        raise ValueError("Missing environment variable RESET_TOKEN")
+    token = request.args.get('token')
+    ae = ApiErrors()
+    if token is None:
+        ae.addError('token', 'Vous devez préciser un jeton dans l''adresse (token=XXX)')
+    if not token == RESET_TOKEN:
+        ae.addError('token', 'Le jeton est invalide')
+    if ae.errors:
+        raise ae
+
+def is_resetable(model_name):
+    model = getattr(models, model_name)
+    return not model_name == 'PcObject'\
+           and isclass(model)\
+           and issubclass(model, PcObject)
+
+@app.route('/reset/', methods=['GET'])
+def reset():
+    check_token()
+    return "\n".join([request.host_url+'export/'+model_name
+                                      +'?token='+request.args.get('token')
+                      for model_name in filter(is_resetable, models.__all__)])
+
+@app.route('/reset/<model_name>', methods=['GET'])
+def reset_table(model_name):
+    check_token()
+    ae = ApiErrors()
+    try:
+        model = getattr(models, model_name)
+    except KeyError:
+        ae.addError('global', 'Nom de classe incorrect : '+model_name)
+        return jsonify(ae.errors), 400
+
+    if not is_resetable(model_name):
+        ae.addError('global', 'Classe non exportable : '+model_name)
+        return jsonify(ae.errors), 400
+
+    model.delete()
+    deleted_count = db.session.commit()
+
+    return jsonify({ "modelName": model_name, "count": deleted_count })


### PR DESCRIPTION
Pour faire le test ci end to end... Il faut que l'instance circle ci frontend fasse ses testcafés avec un backend tout frais bien reset, qui lui est permanent (c'est le serveur sur https://api.passculture-dev.beta.gouv.fr)

un moyen ici un peu ... "dangereux", est de créer une route reset, que le testcafe irait pinger avant le debut de chaque session de tests....

Et c'est pas mal de faire la même logique qu'avec la route export, ie qu'on peut faire des routes 
/reset/<model_name>, comme ça le testcafé de la webapp va pinger plusieurs endpoints (genre essentiellement /reset/users,  /reset/offers, /reset/mediations...), et le testcafe webapp lui tape plutot une liste du genre (/reset/users,  /reset/recommendations, etc...)

OU sans doute, moins generique:
on fait deux routes:
/reset/pro

/reset/webapp

dans lesquelles sont clairement ecrites toutes les tables à reset spécifiquement pour chaque application.

Et on pourrait faire en sorte que ces routes sont importés que exclusivement dans le cas du serveur DEV. (et jamais prod)

dites moi ce que vous en pensez.



