### PR TITLE
517 paying offers

### DIFF
--- a/models/offer.py
+++ b/models/offer.py
@@ -70,7 +70,7 @@ class Offer(PcObject,
     @property
     def stocks(self):
         if self.thing:
-            return self.stocks
+            return self.thingStocks
         elif self.event:
             return list(chain(*map(lambda eo: eo.stocks,
                                    self.eventOccurrences)))

--- a/models/offer.py
+++ b/models/offer.py
@@ -70,7 +70,7 @@ class Offer(PcObject,
     @property
     def stocks(self):
         if self.thing:
-            return self.thing.stocks
+            return self.stocks
         elif self.event:
             return list(chain(*map(lambda eo: eo.stocks,
                                    self.eventOccurrences)))

--- a/models/stock.py
+++ b/models/stock.py
@@ -53,7 +53,9 @@ class Stock(PcObject,
                         nullable=True)
 
     offer = relationship('Offer',
-                         foreign_keys=[offerId])
+                         foreign_keys=[offerId],
+                         backref = 'stocks')
+
 
     price = Column(Numeric(10, 2),
                    nullable=False)

--- a/models/stock.py
+++ b/models/stock.py
@@ -54,7 +54,7 @@ class Stock(PcObject,
 
     offer = relationship('Offer',
                          foreign_keys=[offerId],
-                         backref = 'stocks')
+                         backref = 'thingStocks')
 
 
     price = Column(Numeric(10, 2),

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from flask import current_app as app
 from sqlalchemy import func
 from sqlalchemy.orm import aliased
 
@@ -62,11 +61,7 @@ def not_currently_recommended_offers(query, user):
     return query
 
 
-def get_offers_by_type(offer_type,
-                          user=None,
-                          coords=None,
-                          departement_codes=None,
-                          offer_id=None):
+def get_offers_by_type(offer_type, user=None, departement_codes=None, offer_id=None):
     query = Offer.query
     if offer_type == Event:
         query = query.join(aliased(EventOccurrence))

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -1,25 +1,26 @@
 """ user mediations routes """
 from random import shuffle
+
 from flask import current_app as app, jsonify, request
 from flask_login import current_user, login_required
 
-from domain.build_recommendations import build_mixed_recommendations,\
-                                         move_requested_recommendation_first,\
-                                         move_tutorial_recommendations_first
-from models import Recommendation, PcObject
-from recommendations_engine import create_recommendations_for_discovery,\
-                                   create_recommendations_for_search,\
-                                   give_requested_recommendation_to_user,\
-                                   RecommendationNotFoundException
+from domain.build_recommendations import build_mixed_recommendations, \
+    move_requested_recommendation_first, \
+    move_tutorial_recommendations_first
+from models import PcObject, Recommendation
+from recommendations_engine import create_recommendations_for_discovery, \
+    create_recommendations_for_search
+from recommendations_engine import give_requested_recommendation_to_user, RecommendationNotFoundException
 from repository.booking_queries import find_bookings_from_recommendation
-from repository.recommendation_queries import count_read_recommendations_for_user,\
-                                              find_all_read_recommendations,\
-                                              find_all_unread_recommendations
+from repository.recommendation_queries import count_read_recommendations_for_user, \
+    find_all_unread_recommendations, \
+    find_all_read_recommendations
 from utils.config import BLOB_SIZE, BLOB_READ_NUMBER, BLOB_UNREAD_NUMBER
 from utils.human_ids import dehumanize
 from utils.includes import BOOKING_INCLUDES, RECOMMENDATION_INCLUDES
 from utils.logger import logger
 from utils.rest import expect_json_data
+
 
 @app.route('/recommendations', methods=['GET'])
 @login_required
@@ -79,7 +80,6 @@ def put_recommendations():
     unread_recos = find_all_unread_recommendations(current_user, seen_recommendation_ids)
     read_recos = find_all_read_recommendations(current_user, seen_recommendation_ids)
 
-
     needed_new_recos = BLOB_SIZE \
                        - min(len(unread_recos), BLOB_UNREAD_NUMBER) \
                        - min(len(read_recos), BLOB_READ_NUMBER)
@@ -93,7 +93,6 @@ def put_recommendations():
     logger.info('(new reco) count %i', len(created_recommendations))
 
     recommendations = build_mixed_recommendations(created_recommendations, read_recos, unread_recos)
-
     shuffle(recommendations)
 
     all_read_recos_count = count_read_recommendations_for_user(current_user)

--- a/tests/12_routes_recommendations_test.py
+++ b/tests/12_routes_recommendations_test.py
@@ -9,7 +9,7 @@ from models import PcObject
 from tests.conftest import clean_database
 from utils.config import BLOB_SIZE
 from utils.human_ids import humanize
-from utils.test_utils import API_URL, req, req_with_auth, create_offerer, create_venue, create_event_offer, create_user, \
+from utils.test_utils import API_URL, req_with_auth, create_offerer, create_venue, create_event_offer, create_user, \
     create_event_occurrence, create_stock_from_event_occurrence, create_thing_offer, create_stock_from_offer, \
     create_recommendation
 
@@ -61,15 +61,6 @@ def subtest_recos_with_params(params,
     assert_no_duplicate_mediations(recos)
     assert_recos_offer_venue_is_in_93_is_event_is_not_national(recos)
     return recos
-
-
-@pytest.mark.standalone
-def test_put_recommendations_works_only_when_logged_in():
-    # when
-    response = req.put(RECOMMENDATION_URL)
-
-    # then
-    assert response.status_code == 401
 
 
 def test_put_recommendations_returns_a_list_of_recos_starting_with_two_tutos():

--- a/tests/domain_build_recommendations_test.py
+++ b/tests/domain_build_recommendations_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from domain.build_recommendations import build_mixed_recommendations
@@ -96,6 +98,22 @@ def test_build_mixed_recommendations_with_read_recommendations_and_unread_but_no
 
 @pytest.mark.standalone
 def test_build_mixed_recommendations_with_all_sorts_of_recommendations():
+    # given
+    created_recommendations = [create_recommendation(id=5), create_recommendation(id=6)]
+    read_recommendations = [create_recommendation(id=1), create_recommendation(id=2)]
+    unread_recommendations = [create_recommendation(id=3), create_recommendation(id=4)]
+
+    # when
+    created_recommendations = build_mixed_recommendations(created_recommendations, read_recommendations,
+                                                          unread_recommendations)
+
+    # then
+    assert [r.id for r in created_recommendations] == [5, 6, 3, 4, 1, 2]
+
+
+@pytest.mark.standalone
+@patch('domain.build_recommendations.feature_paid_offers_enabled', return_value=False)
+def test_build_mixed_recommendations_removes_the_recommendations_on_paid_offers_if_feature_is_disabled(feature_enabled):
     # given
     created_recommendations = [create_recommendation(id=5), create_recommendation(id=6)]
     read_recommendations = [create_recommendation(id=1), create_recommendation(id=2)]

--- a/tests/domain_build_recommendations_test.py
+++ b/tests/domain_build_recommendations_test.py
@@ -3,7 +3,17 @@ from unittest.mock import patch
 import pytest
 
 from domain.build_recommendations import build_mixed_recommendations
-from utils.test_utils import create_recommendation
+from models import Offer
+from utils.test_utils import create_recommendation, create_stock
+
+
+class MockedOffer(Offer):
+    def __init__(self, stocks):
+        self._stocks = stocks
+
+    @property
+    def stocks(self):
+        return self._stocks
 
 
 @pytest.mark.standalone
@@ -115,13 +125,22 @@ def test_build_mixed_recommendations_with_all_sorts_of_recommendations():
 @patch('domain.build_recommendations.feature_paid_offers_enabled', return_value=False)
 def test_build_mixed_recommendations_removes_the_recommendations_on_paid_offers_if_feature_is_disabled(feature_enabled):
     # given
-    created_recommendations = [create_recommendation(id=5), create_recommendation(id=6)]
-    read_recommendations = [create_recommendation(id=1), create_recommendation(id=2)]
-    unread_recommendations = [create_recommendation(id=3), create_recommendation(id=4)]
+
+    paid_stock = create_stock(price=10)
+    free_stock = create_stock(price=0)
+    offer_with_paid_stock = MockedOffer([paid_stock, free_stock])
+    offer_with_free_stock = MockedOffer([free_stock])
+
+    created_recommendations = [create_recommendation(id=5, offer=offer_with_paid_stock),
+                               create_recommendation(id=6, offer=offer_with_free_stock)]
+    read_recommendations = [create_recommendation(id=1, offer=offer_with_free_stock),
+                            create_recommendation(id=2, offer=offer_with_free_stock)]
+    unread_recommendations = [create_recommendation(id=3, offer=offer_with_paid_stock),
+                              create_recommendation(id=4, offer=offer_with_paid_stock)]
 
     # when
     created_recommendations = build_mixed_recommendations(created_recommendations, read_recommendations,
                                                           unread_recommendations)
 
     # then
-    assert [r.id for r in created_recommendations] == [5, 6, 3, 4, 1, 2]
+    assert [r.id for r in created_recommendations] == [6, 1, 2]

--- a/tests/score_offer_test.py
+++ b/tests/score_offer_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from models import Offer, Event, Mediation, Stock, Thing
+from models import Offer, Event, Mediation
 from recommendations_engine.offers import score_offer
 
 
@@ -48,64 +48,3 @@ def test_score_offer_returns_27_for_an_event(specific_score_event, randint):
 
     # then
     assert score == 27
-
-
-@patch('recommendations_engine.offers.feature_paid_offers_enabled')
-def test_score_offer_returns_none_given_a_paid_offer_if_feature_is_disabled(feature_paid_offers_enabled):
-    # given
-    stock = Stock()
-    stock.price = 100
-
-    offer = Offer()
-    offer.thing = Thing()
-    offer.thing.stocks = [stock]
-    offer.thing.thumbCount = 1
-    feature_paid_offers_enabled.return_value = False
-
-    # when
-    score = score_offer(offer)
-
-    # then
-    assert score is None
-
-
-@patch('recommendations_engine.offers.randint')
-@patch('recommendations_engine.offers.feature_paid_offers_enabled')
-def test_score_offer_returns_a_score_given_a_paid_offer_if_feature_is_enabled(feature_paid_offers_enabled, randint):
-    # given
-    randint.return_value = 4
-    stock = Stock()
-    stock.price = 100
-
-    offer = Offer()
-    offer.thing = Thing()
-    offer.thing.stocks = [stock]
-    offer.thing.thumbCount = 1
-    feature_paid_offers_enabled.return_value = True
-
-    # when
-    score = score_offer(offer)
-
-    # then
-    assert score == 4
-
-
-@patch('recommendations_engine.offers.randint')
-@patch('recommendations_engine.offers.feature_paid_offers_enabled')
-def test_score_offer_returns_a_score_given_a_free_offer_if_feature_is_disabled(feature_paid_offers_enabled, randint):
-    # given
-    randint.return_value = 4
-    stock = Stock()
-    stock.price = 0
-
-    offer = Offer()
-    offer.thing = Thing()
-    offer.thing.stocks = [stock]
-    offer.thing.thumbCount = 1
-    feature_paid_offers_enabled.return_value = False
-
-    # when
-    score = score_offer(offer)
-
-    # then
-    assert score == 4

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -294,6 +294,13 @@ def create_stock_from_offer(offerer, offer, price=10, available=10):
     return stock
 
 
+def create_stock(price=10, available=10):
+    stock = Stock()
+    stock.price = price
+    stock.available = available
+    return stock
+
+
 def create_stock_with_thing_offer(offerer, venue, thing_offer, price=10, available=50,
                                   booking_email='offer.booking.email@test.com'):
     stock = Stock()

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -309,8 +309,8 @@ def create_stock_with_thing_offer(offerer, venue, thing_offer, price=10, availab
     return stock
 
 
-def create_thing(thing_type='Book', thing_name='Test Book', media_urls='test/urls', author_name='Test Author',
-                 url=None):
+def create_thing(thing_type='Book', thing_name='Test Book', media_urls='test/urls', author_name='Test Author', url=None,
+                 thumb_count=1):
     thing = Thing()
     thing.type = thing_type
     thing.name = thing_name
@@ -318,6 +318,9 @@ def create_thing(thing_type='Book', thing_name='Test Book', media_urls='test/url
     thing.idAtProviders = ''.join(random.choices(string.digits, k=13))
     thing.extraData = {'author': author_name}
     thing.url = url
+    thing.thumbCount = thumb_count
+    if thumb_count > 0:
+        thing.firstThumbDominantColor = b'123'
     return thing
 
 
@@ -329,13 +332,14 @@ def create_event(event_name='Test event', duration_minutes=60):
 
 
 def create_thing_offer(venue, thing=None, date_created=datetime.utcnow(), booking_email='booking.email@test.com',
-                       thing_type='Book', thing_name='Test Book', media_urls='test/urls', author_name='Test Author'):
+                       thing_type='Book', thing_name='Test Book', media_urls='test/urls', author_name='Test Author',
+                       thumb_count=1):
     offer = Offer()
     if thing:
         offer.thing = thing
     else:
         offer.thing = create_thing(thing_type=thing_type, thing_name=thing_name, media_urls=media_urls,
-                                   author_name=author_name)
+                                   author_name=author_name, thumb_count=thumb_count)
     offer.venue = venue
     offer.dateCreated = date_created
     offer.bookingEmail = booking_email
@@ -407,11 +411,13 @@ def create_user_offerer(user, offerer, validation_token=None, is_admin=False):
     return user_offerer
 
 
-def create_recommendation(offer=None, user=None, id=None):
+def create_recommendation(offer=None, user=None, id=None, date_read=None, valid_until_date=datetime.utcnow() + timedelta(days=7)):
     recommendation = Recommendation()
     recommendation.id = id
     recommendation.offer = offer
     recommendation.user = user
+    recommendation.dateRead = date_read
+    recommendation.validUntilDate = valid_until_date
     return recommendation
 
 


### PR DESCRIPTION
Correction d'un bug de production qu'on croyait avoir fixé.
En fait, avant on ne remontait que les recommendations d'offres gratuites qu'on créait, mais on ne filtrait pas les offres existantes.

Avec cette PR, on va filtrer *toutes* les recommendations qu'on remonte (les lues, non lues, créées).