### PR TITLE
Disable autoflush for <object>.errors in check_and_save

### DIFF
--- a/models/pc_object.py
+++ b/models/pc_object.py
@@ -283,7 +283,8 @@ class PcObject():
         # CUMULATE ERRORS IN ONE SINGLE API ERRORS DURING ADD TIME
         api_errors = ApiErrors()
         for obj in objects:
-            obj_api_errors = obj.errors()
+            with db.session.no_autoflush:
+                obj_api_errors = obj.errors()
             if obj_api_errors.errors.keys():
                 api_errors.errors.update(obj_api_errors.errors)
             else:


### PR DESCRIPTION
Sinon, on faisait dans certains cas (signup pro par ex) un flush donc un commit des objets qui auraient du être validés.