### PR TITLE
Populate from dict deserializes strings as datetimes

### DIFF
--- a/models/pc_object.py
+++ b/models/pc_object.py
@@ -271,16 +271,7 @@ class PcObject():
                     except InvalidOperation:
                         raise TypeError('Invalid value for %s: %r' % (key, value), 'decimal', key)
                 elif isinstance(value, str) and isinstance(col.type, DateTime):
-                    datetime_value = None
-                    valid_patterns = ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%SZ']
-
-                    for pattern in valid_patterns:
-                        if match_format(value, pattern):
-                            datetime_value = datetime.strptime(value, pattern)
-
-                    if not datetime_value:
-                        raise TypeError('Invalid value for %s: %r' % (key, value), 'datetime', key)
-
+                    datetime_value = self._deserialize_datetime(key, value)
                     setattr(self, key, datetime_value)
                 else:
                     setattr(self, key, value)
@@ -339,3 +330,16 @@ class PcObject():
             else str(self.id) + "/" + humanize(self.id)
         return '<%s #%s>' % (self.__class__.__name__,
                              id)
+
+    def _deserialize_datetime(self, key, value):
+        valid_patterns = ['%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%SZ']
+        datetime_value = None
+
+        for pattern in valid_patterns:
+            if match_format(value, pattern):
+                datetime_value = datetime.strptime(value, pattern)
+
+        if not datetime_value:
+            raise TypeError('Invalid value for %s: %r' % (key, value), 'datetime', key)
+
+        return datetime_value

--- a/tests/models_pc_object_test.py
+++ b/tests/models_pc_object_test.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+import pytest
+from sqlalchemy import Column, DateTime
+
+from models import PcObject
+from models.db import Model
+
+
+class TimeInterval(PcObject, Model):
+    start = Column(DateTime)
+    end = Column(DateTime)
+
+
+time_interval = TimeInterval()
+time_interval.start = datetime(2018, 1, 1, 10, 20, 30, 111000)
+time_interval.end = datetime(2018, 2, 2, 5, 15, 25, 222000)
+
+
+def test_populate_from_dict_deserializes_datetimes():
+    # given
+    raw_data = {'start': '2018-03-03T15:25:35.123Z', 'end': '2018-04-04T20:10:30.456Z'}
+
+    # when
+    time_interval.populateFromDict(raw_data)
+
+    # then
+    assert time_interval.start == datetime(2018, 3, 3, 15, 25, 35, 123000)
+    assert time_interval.end == datetime(2018, 4, 4, 20, 10, 30, 456000)
+
+
+def test_populate_from_dict_deserializes_datetimes_without_milliseconds():
+    # given
+    raw_data = {'start': '2018-03-03T15:25:35', 'end': '2018-04-04T20:10:30'}
+
+    # when
+    time_interval.populateFromDict(raw_data)
+
+    # then
+    assert time_interval.start == datetime(2018, 3, 3, 15, 25, 35)
+    assert time_interval.end == datetime(2018, 4, 4, 20, 10, 30)
+
+
+def test_populate_from_dict_deserializes_datetimes_without_milliseconds_with_trailing_z():
+    # given
+    raw_data = {'start': '2018-03-03T15:25:35Z', 'end': '2018-04-04T20:10:30Z'}
+
+    # when
+    time_interval.populateFromDict(raw_data)
+
+    # then
+    assert time_interval.start == datetime(2018, 3, 3, 15, 25, 35)
+    assert time_interval.end == datetime(2018, 4, 4, 20, 10, 30)
+
+
+def test_populate_from_dict_raises_type_error_if_raw_date_is_invalid():
+    # given
+    raw_data = {'start': '2018-03-03T15:25:35.123Z', 'end': 'abcdef'}
+
+    # when
+    with pytest.raises(TypeError):
+        time_interval.populateFromDict(raw_data)

--- a/tests/routes_stocks_test.py
+++ b/tests/routes_stocks_test.py
@@ -13,7 +13,7 @@ from utils.test_utils import req_with_auth, API_URL, create_user, create_offerer
 
 @clean_database
 @pytest.mark.standalone
-def test_10_get_stocks_should_return_a_list_of_stocks(app):
+def test_get_stocks_should_return_a_list_of_stocks(app):
     # Given
     user = create_user(email='test@email.com', password='P@55w0rd', is_admin=True, can_book_free_offers=False)
     offerer = create_offerer()
@@ -257,7 +257,7 @@ def test_should_not_update_stock_if_booking_limit_datetime_after_event_occurrenc
     stockId = stock.id
 
     serialized_date = serialize(stock.eventOccurrence.beginningDatetime + timedelta(days=1))
-
+    print(serialized_date)
     # When
     response = req_with_auth('email@test.com', 'P@55w0rd').patch(API_URL + '/stocks/' + humanize(stockId),
                                                                  json={'bookingLimitDatetime': serialized_date})

--- a/utils/date.py
+++ b/utils/date.py
@@ -1,9 +1,19 @@
+from datetime import datetime
 from math import floor
 
 from babel.dates import format_datetime as babel_format_datetime
 from dateutil import tz
 
 from utils.string_processing import parse_timedelta
+
+
+def match_format(value: str, format: str):
+    try:
+        datetime.strptime(value, format)
+    except ValueError:
+        return False
+    else:
+        return True
 
 
 def format_datetime(dt):
@@ -13,7 +23,7 @@ def format_datetime(dt):
 
 
 def format_duration(dr):
-    return floor(parse_timedelta(dr).total_seconds()/60)
+    return floor(parse_timedelta(dr).total_seconds() / 60)
 
 
 def get_dept_timezone(departementCode):


### PR DESCRIPTION
Le bug venait du fait que populateFromDict, dans un patch, mettait les datetimes envoyées en json tel quel dans l'instance d'event occurence (donc comme un string). Donc si on ne changeait qu'une des deux dates, on se retrouvait à comparer des str avec des datimes.

Le fix consiste à faire en sorte que populate from dict transforme les str en datimes.