### PR TITLE
577 error 500 when in route things and no venue

### DIFF
--- a/routes/offerers.py
+++ b/routes/offerers.py
@@ -80,10 +80,10 @@ def create_offerer():
         user_offerer = offerer.give_rights(current_user,
                                            RightsType.admin)
         PcObject.check_and_save(offerer, user_offerer)
-    try:
-        maybe_send_offerer_validation_email(offerer, user_offerer, app.mailjet_client.send.create)
-    except MailServiceException as e:
-        app.logger.error('Mail service failure', e)
+        try:
+            maybe_send_offerer_validation_email(offerer, user_offerer, app.mailjet_client.send.create)
+        except MailServiceException as e:
+            app.logger.error('Mail service failure', e)
     return jsonify(offerer._asdict(include=OFFERER_INCLUDES)), 201
 
 

--- a/tests/routes_offerers_test.py
+++ b/tests/routes_offerers_test.py
@@ -1,7 +1,6 @@
 """ routes offerer """
 import secrets
 from datetime import timedelta, datetime
-from pprint import pprint
 
 import pytest
 

--- a/tests/routes_offerers_test.py
+++ b/tests/routes_offerers_test.py
@@ -1,6 +1,7 @@
 """ routes offerer """
 import secrets
 from datetime import timedelta, datetime
+from pprint import pprint
 
 import pytest
 
@@ -354,7 +355,7 @@ def test_post_offerers_when_admin(app):
         'postalCode': '93100',
         'city': 'Montreuil'
     }
-    response = auth_request.post(API_URL + '/offerers/', body)
+    response = auth_request.post(API_URL + '/offerers', json=body)
 
     # then
     assert response.status_code == 201

--- a/tests/routes_offerers_test.py
+++ b/tests/routes_offerers_test.py
@@ -336,3 +336,25 @@ def test_get_offerers_should_not_send_offerer_to_user_offerer_not_validated(app)
     # then
     assert response.status_code == 404
     assert response.json()['global'] == ['La page que vous recherchez n\'existe pas']
+
+
+@clean_database
+@pytest.mark.standalone
+def test_post_offerers_when_admin(app):
+    # Given
+    user = create_user(password='p@55sw0rd!', is_admin=True, can_book_free_offers=False)
+    auth_request = req_with_auth(email=user.email, password='p@55sw0rd!')
+    PcObject.check_and_save(user)
+
+    # When
+    body = {
+        'name': 'Test Offerer',
+        'siren': '418166096',
+        'address': '123 rue de Paris',
+        'postalCode': '93100',
+        'city': 'Montreuil'
+    }
+    response = auth_request.post(API_URL + '/offerers/', body)
+
+    # then
+    assert response.status_code == 201


### PR DESCRIPTION
Quand un admin essayait de créer un offerer, l'envoi d'email de validation plantait parce qu'il n'y avait pas de création d'user_offerer. Vu qu'on n'a a priori pas besoin de valider les offerers créés par les admins, j'ai mis l'envoi d'email uniquement lorsque l'user n'est pas admin