### PR TITLE
Not making tests fail when open agenda is down

### DIFF
--- a/tests/19_routes_venue_providers_test.py
+++ b/tests/19_routes_venue_providers_test.py
@@ -1,9 +1,19 @@
 from time import sleep
 
+import pytest
+import requests
+
 from models.provider import Provider
 from utils.human_ids import humanize
 from utils.test_utils import API_URL, req_with_auth
 
+
+def check_open_agenda_api_is_down():
+    response = requests.get('https://openagenda.com/agendas/86585975/events.json?limit=1')
+    response_json = response.json()
+    unsuccessful_request = ('success' in response_json) and not response_json['success']
+    status_code_not_200 = (response.status_code != 200)
+    return unsuccessful_request or status_code_not_200
 
 def test_10_delete_venue_provider():
     r_get1 = req_with_auth().get(API_URL + '/venueProviders/AE')
@@ -12,6 +22,7 @@ def test_10_delete_venue_provider():
     assert r_get2.status_code == 404
 
 
+@pytest.mark.skipif(check_open_agenda_api_is_down(), reason="Open Agenda API is down")
 def test_11_create_venue_provider(app):
     openagenda_provider = Provider.getByClassName('OpenAgendaEvents')
     vp_data = {'providerId': humanize(openagenda_provider.id),


### PR DESCRIPTION
added skipif to test_11_create_venue_provider - skip if open agenda is down