### PR TITLE
#859 Return offerers with pending validation

### DIFF
--- a/repository/user_offerer_queries.py
+++ b/repository/user_offerer_queries.py
@@ -1,4 +1,4 @@
-from models import UserOfferer, User
+from models import UserOfferer, User, Offerer
 
 
 def find_user_offerer_email(user_offerer_id):
@@ -12,3 +12,9 @@ def filter_query_where_user_is_user_offerer_and_is_validated(query, user):
 
 def count_user_offerers_by_offerer(offerer):
     return UserOfferer.query.filter_by(offerer=offerer).count()
+
+
+def find_pending_offerer_by_user(user):
+    return Offerer.query.join(UserOfferer) \
+        .filter(UserOfferer.validationToken.isnot(None)) \
+        .filter_by(user=user).all()

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -11,6 +11,26 @@ OFFERER_INCLUDES = [
     "isValidated"
 ]
 
+PENDING_OFFERER_INCLUDES = [
+    "name",
+    "siren",
+    "-address",
+    "-bic",
+    "-city",
+    "-dateCreated",
+    "-dateModifiedAtLastProvider",
+    "-firstThumbDominantColor",
+    "-iban",
+    "-id",
+    "-idAtProviders",
+    "-isActive",
+    "-lastProviderId",
+    "-modelName",
+    "-postalCode",
+    "siren",
+    "-thumbCount"
+]
+
 EVENT_OCCURRENCE_INCLUDES = [
     'stocks'
 ]


### PR DESCRIPTION
Annule et remplace https://github.com/betagouv/pass-culture-api/pull/261

L'idée et de renvoyer les `Offerer` en attente de validation (avec seulement des donnés partielles) pour pouvoir afficher à l'utilisateurs ces `Oferrer` avec un statut spécifique (et pas d'action possible).

Le code que je viens de pousser me semble fonctionner (je vais ajouter des tests dans la foulée) mais il me semble aussi assez dégeu.

Dans l'absolu j'ai l'impression qu'il serait plus clean de faire :
 * une seule requête en BDD en excluant pas les pendings `Oferrer` (avec un sort pour qu'ils remontent en premier)
 * Un map sur le résultat pour faire un `._asdict()` qui va bien selon le statut pour cacher les champs au besoin.

## Danger
Avec la soluce actuelle on by pass entre autre la pagination, donc on aura potentiellement + de N résultas sur la première page. Si l'user s'amuse à ajouter plein d'`Offerer` on pourrait générer des queries / résutats énormes puisque pas limités qui ferait ramer le serveur.