### PR TITLE
[1014] [BUG] Send emails to passculture-dev instead of pass-culture for testing

### DIFF
--- a/domain/admin_emails.py
+++ b/domain/admin_emails.py
@@ -27,8 +27,7 @@ def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email
 
 def send_payment_transaction_email(xml_attachment, send_create_email):
     email = make_payment_transaction_email(xml_attachment)
-    recipients = [{"Email": "passculture-dev@beta.gouv.fr",
-                "Name": "Compta pass Culture"}]
+    recipients = ["passculture-dev@beta.gouv.fr"]
     email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)

--- a/domain/admin_emails.py
+++ b/domain/admin_emails.py
@@ -1,3 +1,4 @@
+from domain.user_emails import edit_email_html_part_and_recipients
 from utils.mailing import write_object_validation_email, check_if_email_sent, make_payment_transaction_email, \
     make_venue_validation_email
 
@@ -12,7 +13,6 @@ def send_dev_email(subject, html_text, send_create_email):
     }
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
-
 
 
 def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email):
@@ -32,5 +32,6 @@ def send_payment_transaction_email(xml_attachment, send_create_email):
 
 def send_venue_validation_email(venue, send_create_email):
     email = make_venue_validation_email(venue)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], email['To'])
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)

--- a/domain/admin_emails.py
+++ b/domain/admin_emails.py
@@ -1,6 +1,5 @@
-from domain.user_emails import edit_email_html_part_and_recipients
 from utils.mailing import write_object_validation_email, check_if_email_sent, make_payment_transaction_email, \
-    make_venue_validation_email
+    make_venue_validation_email, edit_email_html_part_and_recipients
 
 
 def send_dev_email(subject, html_text, send_create_email):

--- a/domain/admin_emails.py
+++ b/domain/admin_emails.py
@@ -19,6 +19,8 @@ def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email
     if offerer.isValidated and user_offerer.isValidated:
         return
     email = write_object_validation_email(offerer, user_offerer)
+    recipients = ['passculture@beta.gouv.fr']
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
 
     check_if_email_sent(mail_result)
@@ -26,12 +28,16 @@ def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email
 
 def send_payment_transaction_email(xml_attachment, send_create_email):
     email = make_payment_transaction_email(xml_attachment)
+    recipients = [{"Email": "passculture-dev@beta.gouv.fr",
+                "Name": "Compta pass Culture"}]
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
 
 def send_venue_validation_email(venue, send_create_email):
     email = make_venue_validation_email(venue)
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], email['To'])
+    recipients = ['passculture@beta.gouv.fr']
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)

--- a/domain/admin_emails.py
+++ b/domain/admin_emails.py
@@ -1,5 +1,5 @@
 from utils.mailing import write_object_validation_email, check_if_email_sent, make_payment_transaction_email, \
-    make_venue_validation_email, edit_email_html_part_and_recipients
+    make_venue_validation_email, compute_email_html_part_and_recipients
 
 
 def send_dev_email(subject, html_text, send_create_email):
@@ -19,7 +19,7 @@ def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email
         return
     email = write_object_validation_email(offerer, user_offerer)
     recipients = ['passculture@beta.gouv.fr']
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
 
     check_if_email_sent(mail_result)
@@ -28,7 +28,7 @@ def maybe_send_offerer_validation_email(offerer, user_offerer, send_create_email
 def send_payment_transaction_email(xml_attachment, send_create_email):
     email = make_payment_transaction_email(xml_attachment)
     recipients = ["passculture-dev@beta.gouv.fr"]
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -36,6 +36,6 @@ def send_payment_transaction_email(xml_attachment, send_create_email):
 def send_venue_validation_email(venue, send_create_email):
     email = make_venue_validation_email(venue)
     recipients = ['passculture@beta.gouv.fr']
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)

--- a/domain/user_emails.py
+++ b/domain/user_emails.py
@@ -88,7 +88,8 @@ def send_offerer_driven_cancellation_email_to_offerer(booking, send_create_email
 
 def send_reset_password_email(user, send_create_email, app_origin_url):
     email = make_reset_password_email(user, app_origin_url)
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], email['To'])
+    recipients =  [user.email]
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 

--- a/domain/user_emails.py
+++ b/domain/user_emails.py
@@ -6,7 +6,7 @@ from utils.mailing import make_user_booking_recap_email, \
     make_offerer_booking_recap_email_after_user_action, make_offerer_driven_cancellation_email_for_user, \
     make_offerer_driven_cancellation_email_for_offerer, make_final_recap_email_for_stock_with_event, \
     check_if_email_sent, make_reset_password_email, make_validation_confirmation_email, make_batch_cancellation_email, \
-    make_user_validation_email, make_venue_validation_confirmation_email, edit_email_html_part_and_recipients
+    make_user_validation_email, make_venue_validation_confirmation_email, compute_email_html_part_and_recipients
 
 
 def send_final_booking_recap_email(stock, send_create_email):
@@ -19,7 +19,7 @@ def send_final_booking_recap_email(stock, send_create_email):
     if stock.resolvedOffer.bookingEmail:
         recipients.append(stock.resolvedOffer.bookingEmail)
 
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -34,7 +34,7 @@ def send_booking_recap_emails(booking, send_create_email):
     if booking.stock.resolvedOffer.bookingEmail:
         recipients.append(booking.stock.resolvedOffer.bookingEmail)
 
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -44,7 +44,7 @@ def send_booking_confirmation_email_to_user(booking, send_create_email, is_cance
     email = make_user_booking_recap_email(booking, is_cancellation)
     recipients = [booking.user.email]
 
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -54,7 +54,7 @@ def send_user_driven_cancellation_email_to_user(booking, send_create_email):
     email = make_user_booking_recap_email(booking, is_cancellation=True)
     recipients = [booking.user.email]
 
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -63,7 +63,7 @@ def send_user_driven_cancellation_email_to_user(booking, send_create_email):
 def send_user_driven_cancellation_email_to_offerer(booking, send_create_email):
     email = make_offerer_booking_recap_email_after_user_action(booking, is_cancellation=True)
     recipients = [booking.stock.resolvedOffer.venue.bookingEmail]
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -71,7 +71,7 @@ def send_user_driven_cancellation_email_to_offerer(booking, send_create_email):
 def send_offerer_driven_cancellation_email_to_user(booking, send_create_email):
     email = make_offerer_driven_cancellation_email_for_user(booking)
     recipients = [booking.user.email]
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -81,7 +81,7 @@ def send_offerer_driven_cancellation_email_to_offerer(booking, send_create_email
     if offerer_email:
         recipients = [offerer_email]
         email = make_offerer_driven_cancellation_email_for_offerer(booking)
-        email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+        email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
         mail_result = send_create_email(data=email)
         check_if_email_sent(mail_result)
 
@@ -89,7 +89,7 @@ def send_offerer_driven_cancellation_email_to_offerer(booking, send_create_email
 def send_reset_password_email(user, send_create_email, app_origin_url):
     email = make_reset_password_email(user, app_origin_url)
     recipients =  [user.email]
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -98,7 +98,7 @@ def send_validation_confirmation_email(user_offerer, offerer, send_create_email)
     offerer_id = _get_offerer_id(offerer, user_offerer)
     recipients = find_all_emails_of_user_offerers_admins(offerer_id)
     email = make_validation_confirmation_email(user_offerer, offerer)
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -114,7 +114,7 @@ def send_batch_cancellation_email_to_offerer(bookings, cancellation_case, send_c
     if offerer_email:
         recipients = [offerer_email]
         email = make_batch_cancellation_email(bookings, cancellation_case)
-        email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+        email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
         mail_result = send_create_email(data=email)
         check_if_email_sent(mail_result)
 
@@ -132,7 +132,7 @@ def send_cancellation_emails_to_user_and_offerer(booking, is_offerer_cancellatio
 def send_venue_validation_confirmation_email(venue, send_create_email):
     recipients = find_all_emails_of_user_offerers_admins(venue.managingOffererId)
     email = make_venue_validation_confirmation_email(venue)
-    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = compute_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 

--- a/domain/user_emails.py
+++ b/domain/user_emails.py
@@ -1,14 +1,12 @@
 from repository.booking_queries import find_all_ongoing_bookings_by_stock
-from repository.features import feature_send_mail_to_users_enabled
 from repository.stock_queries import set_booking_recap_sent_and_save
 from repository.user_queries import find_all_emails_of_user_offerers_admins
-from utils.config import ENV
 from utils.logger import logger
 from utils.mailing import make_user_booking_recap_email, \
     make_offerer_booking_recap_email_after_user_action, make_offerer_driven_cancellation_email_for_user, \
     make_offerer_driven_cancellation_email_for_offerer, make_final_recap_email_for_stock_with_event, \
     check_if_email_sent, make_reset_password_email, make_validation_confirmation_email, make_batch_cancellation_email, \
-    make_user_validation_email, make_venue_validation_confirmation_email
+    make_user_validation_email, make_venue_validation_confirmation_email, edit_email_html_part_and_recipients
 
 
 def send_final_booking_recap_email(stock, send_create_email):
@@ -150,14 +148,3 @@ def _get_offerer_id(offerer, user_offerer):
     else:
         offerer_id = offerer.id
     return offerer_id
-
-
-def edit_email_html_part_and_recipients(email_html_part, recipients):
-    if feature_send_mail_to_users_enabled():
-        email_to = ", ".join(recipients)
-    else:
-        email_html_part = ('<p>This is a test (ENV=%s). In production, email would have been sent to : ' % ENV) \
-                          + ", ".join(recipients) \
-                          + '</p>' + email_html_part
-        email_to = 'passculture-dev@beta.gouv.fr'
-    return email_html_part, email_to

--- a/domain/user_emails.py
+++ b/domain/user_emails.py
@@ -21,7 +21,7 @@ def send_final_booking_recap_email(stock, send_create_email):
     if stock.resolvedOffer.bookingEmail:
         recipients.append(stock.resolvedOffer.bookingEmail)
 
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -36,7 +36,7 @@ def send_booking_recap_emails(booking, send_create_email):
     if booking.stock.resolvedOffer.bookingEmail:
         recipients.append(booking.stock.resolvedOffer.bookingEmail)
 
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -46,7 +46,7 @@ def send_booking_confirmation_email_to_user(booking, send_create_email, is_cance
     email = make_user_booking_recap_email(booking, is_cancellation)
     recipients = [booking.user.email]
 
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -56,7 +56,7 @@ def send_user_driven_cancellation_email_to_user(booking, send_create_email):
     email = make_user_booking_recap_email(booking, is_cancellation=True)
     recipients = [booking.user.email]
 
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
 
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
@@ -65,7 +65,7 @@ def send_user_driven_cancellation_email_to_user(booking, send_create_email):
 def send_user_driven_cancellation_email_to_offerer(booking, send_create_email):
     email = make_offerer_booking_recap_email_after_user_action(booking, is_cancellation=True)
     recipients = [booking.stock.resolvedOffer.venue.bookingEmail]
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -73,7 +73,7 @@ def send_user_driven_cancellation_email_to_offerer(booking, send_create_email):
 def send_offerer_driven_cancellation_email_to_user(booking, send_create_email):
     email = make_offerer_driven_cancellation_email_for_user(booking)
     recipients = [booking.user.email]
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -83,7 +83,7 @@ def send_offerer_driven_cancellation_email_to_offerer(booking, send_create_email
     if offerer_email:
         recipients = [offerer_email]
         email = make_offerer_driven_cancellation_email_for_offerer(booking)
-        email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+        email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
         mail_result = send_create_email(data=email)
         check_if_email_sent(mail_result)
 
@@ -98,7 +98,7 @@ def send_validation_confirmation_email(user_offerer, offerer, send_create_email)
     offerer_id = _get_offerer_id(offerer, user_offerer)
     recipients = find_all_emails_of_user_offerers_admins(offerer_id)
     email = make_validation_confirmation_email(user_offerer, offerer)
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -114,7 +114,7 @@ def send_batch_cancellation_email_to_offerer(bookings, cancellation_case, send_c
     if offerer_email:
         recipients = [offerer_email]
         email = make_batch_cancellation_email(bookings, cancellation_case)
-        email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+        email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
         mail_result = send_create_email(data=email)
         check_if_email_sent(mail_result)
 
@@ -132,7 +132,7 @@ def send_cancellation_emails_to_user_and_offerer(booking, is_offerer_cancellatio
 def send_venue_validation_confirmation_email(venue, send_create_email):
     recipients = find_all_emails_of_user_offerers_admins(venue.managingOffererId)
     email = make_venue_validation_confirmation_email(venue)
-    email['Html-part'], email['To'] = _edit_email_html_part_and_recipients(email['Html-part'], recipients)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], recipients)
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 
@@ -151,7 +151,7 @@ def _get_offerer_id(offerer, user_offerer):
     return offerer_id
 
 
-def _edit_email_html_part_and_recipients(email_html_part, recipients):
+def edit_email_html_part_and_recipients(email_html_part, recipients):
     if feature_send_mail_to_users_enabled():
         email_to = ", ".join(recipients)
     else:

--- a/domain/user_emails.py
+++ b/domain/user_emails.py
@@ -1,7 +1,7 @@
 from repository.booking_queries import find_all_ongoing_bookings_by_stock
 from repository.features import feature_send_mail_to_users_enabled
-from repository.user_queries import find_all_emails_of_user_offerers_admins
 from repository.stock_queries import set_booking_recap_sent_and_save
+from repository.user_queries import find_all_emails_of_user_offerers_admins
 from utils.config import ENV
 from utils.logger import logger
 from utils.mailing import make_user_booking_recap_email, \
@@ -90,6 +90,7 @@ def send_offerer_driven_cancellation_email_to_offerer(booking, send_create_email
 
 def send_reset_password_email(user, send_create_email, app_origin_url):
     email = make_reset_password_email(user, app_origin_url)
+    email['Html-part'], email['To'] = edit_email_html_part_and_recipients(email['Html-part'], email['To'])
     mail_result = send_create_email(data=email)
     check_if_email_sent(mail_result)
 

--- a/tests/domain_internal_emails_test.py
+++ b/tests/domain_internal_emails_test.py
@@ -118,7 +118,7 @@ def test_send_venue_validation_email_when_mailjet_status_code_200_calls_send_cre
 
 
 @pytest.mark.standalone
-def test_send_venue_validation_email_when_feature_send_mail_to_users_disabled_has_pass_culture_dev_as_recipient(app):
+def test_send_venue_validation_email_has_pass_culture_dev_as_recipient_in_dev_environment(app):
     # Given
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -132,11 +132,11 @@ def test_send_venue_validation_email_when_feature_send_mail_to_users_disabled_ha
     with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False):
         send_venue_validation_email(venue, mocked_send_create_email)
 
+    # Then
     mocked_send_create_email.assert_called_once()
     args = mocked_send_create_email.call_args
     assert args[1]['data']['To'] == 'passculture-dev@beta.gouv.fr'
 
-    # Then
 
 
 @pytest.mark.standalone

--- a/tests/domain_internal_emails_test.py
+++ b/tests/domain_internal_emails_test.py
@@ -28,7 +28,7 @@ def test_maybe_send_offerer_validation_email_sends_email_to_pass_culture_when_ob
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True):
         maybe_send_offerer_validation_email(offerer, user_offerer, mocked_send_create_email)
 
     # Then
@@ -58,7 +58,7 @@ def test_maybe_send_offerer_validation_email_sends_email_to_pass_culture_dev_whe
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False):
         maybe_send_offerer_validation_email(offerer, user_offerer, mocked_send_create_email)
 
     # Then
@@ -131,7 +131,7 @@ def test_send_venue_validation_email_when_mailjet_status_code_200_sends_email_to
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True):
         send_venue_validation_email(venue, mocked_send_create_email)
 
     # Then
@@ -154,7 +154,7 @@ def test_send_venue_validation_email_has_pass_culture_dev_as_recipient_when_send
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False):
         send_venue_validation_email(venue, mocked_send_create_email)
 
     # Then

--- a/tests/domain_user_emails_test.py
+++ b/tests/domain_user_emails_test.py
@@ -25,7 +25,7 @@ def test_send_user_driven_cancellation_email_to_user_when_feature_send_mail_to_u
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_user_booking_recap_email',
             return_value={'Html-part': ''}) as make_user_recap_email:
         # When
@@ -48,7 +48,7 @@ def test_send_user_driven_cancellation_email_to_user_when_feature_send_mail_to_u
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_user_booking_recap_email',
             return_value={'Html-part': ''}) as make_user_recap_email:
         # When
@@ -76,7 +76,7 @@ def test_send_user_driven_cancellation_email_to_user_when_status_code_400(app):
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_offerer_booking_recap_email_after_user_action',
             return_value={'Html-part': ''}), pytest.raises(MailServiceException):
         send_user_driven_cancellation_email_to_user(booking, mocked_send_create_email)
@@ -95,7 +95,7 @@ def test_send_user_driven_cancellation_email_to_offerer_when_feature_send_mail_t
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_booking_recap_email_after_user_action',
             return_value={'Html-part': ''}) as make_offerer_recap_email:
         # When
@@ -121,7 +121,7 @@ def test_send_user_driven_cancellation_email_to_offerer_when_feature_send_mail_t
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_offerer_booking_recap_email_after_user_action',
             return_value={'Html-part': ''}) as make_offerer_recap_email:
         # When
@@ -149,7 +149,7 @@ def test_send_user_driven_cancellation_email_to_offerer_when_status_code_400(app
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_offerer_booking_recap_email_after_user_action',
             return_value={'Html-part': ''}), pytest.raises(MailServiceException):
         send_user_driven_cancellation_email_to_offerer(booking, mocked_send_create_email)
@@ -165,7 +165,7 @@ def test_send_offerer_driven_cancellation_email_to_user_when_feature_send_mail_t
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_driven_cancellation_email_for_user',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -189,7 +189,7 @@ def test_send_offerer_driven_cancellation_email_to_user_when_status_code_400(app
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_driven_cancellation_email_for_user',
             return_value={'Html-part': ''}), pytest.raises(MailServiceException):
         send_offerer_driven_cancellation_email_to_user(booking, mocked_send_create_email)
@@ -209,7 +209,7 @@ def test_send_offerer_driven_cancellation_email_to_offerer_when_booking_email(ap
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_driven_cancellation_email_for_offerer',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -236,7 +236,7 @@ def test_send_offerer_driven_cancellation_email_to_offerer_when_no_booking_email
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_driven_cancellation_email_for_offerer',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -258,7 +258,7 @@ def test_send_offerer_driven_cancellation_email_to_offerer_when_status_code_400(
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_offerer_driven_cancellation_email_for_offerer',
             return_value={'Html-part': ''}), pytest.raises(MailServiceException):
         send_offerer_driven_cancellation_email_to_offerer(booking, mocked_send_create_email)
@@ -307,7 +307,7 @@ def test_send_booking_recap_emails_does_not_send_email_to_offer_booking_email_if
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users:
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users:
         send_mail_to_users.return_value = False
         # when
         send_booking_recap_emails(booking, mocked_send_create_email)
@@ -332,7 +332,7 @@ def test_send_booking_recap_emails_sends_email_to_offer_booking_email_if_feature
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users:
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users:
         send_mail_to_users.return_value = True
         # when
         send_booking_recap_emails(booking, mocked_send_create_email)
@@ -359,7 +359,7 @@ def test_send_booking_recap_emails_email_sends_email_only_to_passculture_if_feat
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users:
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users:
         send_mail_to_users.return_value = True
         # when
         send_booking_recap_emails(booking, mocked_send_create_email)
@@ -381,7 +381,7 @@ def test_send_final_booking_recap_email_does_not_send_email_to_offer_booking_ema
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
             'domain.user_emails.set_booking_recap_sent_and_save') as set_booking_recap_sent_and_save:
         send_mail_to_users.return_value = False
         # when
@@ -405,7 +405,7 @@ def test_send_final_booking_recap_email_sends_email_to_offer_booking_email_if_fe
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
             'domain.user_emails.set_booking_recap_sent_and_save') as set_booking_recap_sent_and_save:
         send_mail_to_users.return_value = True
         # when
@@ -431,7 +431,7 @@ def test_send_final_booking_recap_email_sends_email_only_to_passculture_if_featu
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled') as send_mail_to_users, patch(
             'domain.user_emails.set_booking_recap_sent_and_save') as set_booking_recap_sent_and_save:
         send_mail_to_users.return_value = True
         # when
@@ -456,7 +456,7 @@ def test_send_validation_confirmation_email(app):
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_validation_confirmation_email',
             return_value={'Html-part': ''}) as make_cancellation_email, patch(
         'domain.user_emails.find_all_emails_of_user_offerers_admins',
@@ -483,7 +483,7 @@ def test_send_validation_confirmation_email_when_status_code_400(app):
     return_value.status_code = 400
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_validation_confirmation_email', return_value={'Html-part': ''}), patch(
         'domain.user_emails.find_all_emails_of_user_offerers_admins', return_value=['test@email.com']), pytest.raises(
         MailServiceException):
@@ -506,7 +506,7 @@ def test_send_cancellation_emails_to_users_calls_send_offerer_driven_cancellatio
     with patch(
             'domain.user_emails.send_offerer_driven_cancellation_email_to_user') as send_cancellation_email_one_user, patch(
         'domain.user_emails.make_offerer_driven_cancellation_email_for_user',
-        return_value={'Html-part': ''}), patch('domain.user_emails.feature_send_mail_to_users_enabled',
+        return_value={'Html-part': ''}), patch('utils.mailing.feature_send_mail_to_users_enabled',
                                                return_value=True):
         send_batch_cancellation_emails_to_users(bookings, mocked_send_create_email)
 
@@ -525,7 +525,7 @@ def test_send_batch_cancellation_email_to_offerer():
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_batch_cancellation_email',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -550,7 +550,7 @@ def test_send_batch_cancellation_email_to_offerer_event_occurrence_case():
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_batch_cancellation_email',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -575,7 +575,7 @@ def test_send_batch_cancellation_email_to_offerer_email_status_code_500():
     mocked_send_create_email.return_value = return_value
 
     # When
-    with pytest.raises(MailServiceException), patch('domain.user_emails.feature_send_mail_to_users_enabled',
+    with pytest.raises(MailServiceException), patch('utils.mailing.feature_send_mail_to_users_enabled',
                                                     return_value=True), patch(
         'domain.user_emails.make_batch_cancellation_email',
         return_value={'Html-part': ''}):
@@ -594,7 +594,7 @@ def test_send_batch_cancellation_email_to_offerer_feature_send_mail_to_users_ena
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_batch_cancellation_email',
             return_value={'Html-part': ''}) as make_cancellation_email:
         # When
@@ -618,7 +618,7 @@ def test_send_batch_cancellation_email_to_offerer_no_venue_email():
     mocked_send_create_email.return_value = return_value
 
     # When
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_batch_cancellation_email',
             return_value={'Html-part': ''}):
         # When
@@ -638,7 +638,7 @@ def test_send_venue_validation_confirmation_email(app):
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_venue_validation_confirmation_email',
             return_value={'Html-part': ''}) as make_cancellation_email, patch(
         'domain.user_emails.find_all_emails_of_user_offerers_admins',
@@ -665,7 +665,7 @@ def test_send_venue_validation_confirmation_email_has_pass_culutre_dev_as_recipi
     return_value.status_code = 200
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False), patch(
             'domain.user_emails.make_venue_validation_confirmation_email',
             return_value={'Html-part': ''}) as make_cancellation_email, patch(
         'domain.user_emails.find_all_emails_of_user_offerers_admins',
@@ -691,7 +691,7 @@ def test_send_venue_validation_confirmation_email_when_status_code_400(app):
     return_value.status_code = 400
     mocked_send_create_email.return_value = return_value
 
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True), patch(
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True), patch(
             'domain.user_emails.make_venue_validation_confirmation_email', return_value={'Html-part': ''}), patch(
         'domain.user_emails.find_all_emails_of_user_offerers_admins', return_value=['test@email.com']), pytest.raises(
         MailServiceException):
@@ -711,7 +711,7 @@ def test_send_user_validation_email_when_send_create_status_code_200():
 
     # When
     with patch('domain.user_emails.make_user_validation_email', return_value={'Html-part': ''}) as make_email, patch(
-            'domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+            'utils.mailing.feature_send_mail_to_users_enabled', return_value=True):
         send_user_validation_email(user, mocked_send_create_email, True)
     # Then
     mocked_send_create_email.assert_called_once()
@@ -732,7 +732,7 @@ def test_send_user_validation_email_when_send_create_status_code_400():
     # When
     with pytest.raises(MailServiceException), patch('domain.user_emails.make_user_validation_email',
                                                     return_value={'Html-part': ''}) as make_email, patch(
-        'domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+        'utils.mailing.feature_send_mail_to_users_enabled', return_value=True):
         send_user_validation_email(user, mocked_send_create_email, True)
     # Then
     mocked_send_create_email.assert_called_once()
@@ -749,7 +749,7 @@ def test_send_reset_password_email_sends_a_reset_password_email_to_the_recipient
     mocked_send_create_email.return_value = return_value
 
     # when
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=True):
         send_reset_password_email(user, mocked_send_create_email, 'localhost')
 
     # then
@@ -772,7 +772,7 @@ def test_send_reset_password_email_sends_a_reset_password_email_to_the_pass_cult
     mocked_send_create_email.return_value = return_value
 
     # when
-    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False):
+    with patch('utils.mailing.feature_send_mail_to_users_enabled', return_value=False):
         send_reset_password_email(user, mocked_send_create_email, 'localhost')
 
     # then

--- a/tests/domain_user_emails_test.py
+++ b/tests/domain_user_emails_test.py
@@ -757,7 +757,7 @@ def test_send_reset_password_email_sends_a_reset_password_email_to_the_recipient
     args = mocked_send_create_email.call_args
     data = args[1]['data']
     assert data['FromName'] == 'Pass Culture'
-    assert data['FromEmail'] == 'passculture-dev@beta.gouv.fr'
+    assert data['FromEmail'] == 'passculture@beta.gouv.fr'
     assert data['Subject'] == 'Réinitialisation de votre mot de passe'
     assert data['To'] == 'bobby@test.com'
 

--- a/tests/domain_user_emails_test.py
+++ b/tests/domain_user_emails_test.py
@@ -8,7 +8,6 @@ from domain.user_emails import send_user_driven_cancellation_email_to_user, \
     send_booking_confirmation_email_to_user, send_booking_recap_emails, send_final_booking_recap_email, \
     send_validation_confirmation_email, send_batch_cancellation_emails_to_users, \
     send_batch_cancellation_email_to_offerer, send_user_validation_email, send_venue_validation_confirmation_email
-
 from models import Offerer, UserOfferer, User, RightsType
 from utils.mailing import MailServiceException
 from utils.test_utils import create_user, create_booking, create_stock_with_event_offer, create_offerer, create_venue, \
@@ -653,6 +652,32 @@ def test_send_venue_validation_confirmation_email(app):
 
 
 @pytest.mark.standalone
+def test_send_venue_validation_confirmation_email_when_feature_send_mail_to_users_disabled_has_pass_culutre_dev_as_recipient(
+        app):
+    # Given
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    mocked_send_create_email = Mock()
+    return_value = Mock()
+    return_value.status_code = 200
+    mocked_send_create_email.return_value = return_value
+
+    with patch('domain.user_emails.feature_send_mail_to_users_enabled', return_value=False), patch(
+            'domain.user_emails.make_venue_validation_confirmation_email',
+            return_value={'Html-part': ''}) as make_cancellation_email, patch(
+        'domain.user_emails.find_all_admin_offerer_emails', return_value=['admin1@email.com', 'admin2@email.com']):
+        # When
+        send_venue_validation_confirmation_email(venue, mocked_send_create_email)
+
+    # Then
+    make_cancellation_email.assert_called_once_with(venue)
+
+    mocked_send_create_email.assert_called_once()
+    args = mocked_send_create_email.call_args
+    assert args[1]['data']['To'] == 'passculture-dev@beta.gouv.fr'
+
+
+@pytest.mark.standalone
 def test_send_venue_validation_confirmation_email_when_status_code_400(app):
     # Given
     offerer = create_offerer()
@@ -703,7 +728,7 @@ def test_send_user_validation_email_when_send_create_status_code_400():
     # When
     with pytest.raises(MailServiceException), patch('domain.user_emails.make_user_validation_email',
                                                     return_value={'Html-part': ''}) as make_email, patch(
-            'domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
+        'domain.user_emails.feature_send_mail_to_users_enabled', return_value=True):
         send_user_validation_email(user, mocked_send_create_email, True)
     # Then
     mocked_send_create_email.assert_called_once()

--- a/tests/domain_user_emails_test.py
+++ b/tests/domain_user_emails_test.py
@@ -652,7 +652,7 @@ def test_send_venue_validation_confirmation_email(app):
 
 
 @pytest.mark.standalone
-def test_send_venue_validation_confirmation_email_when_feature_send_mail_to_users_disabled_has_pass_culutre_dev_as_recipient(
+def test_send_venue_validation_confirmation_email_has_pass_culutre_dev_as_recipient_in_dev_environment(
         app):
     # Given
     offerer = create_offerer()

--- a/tests/utils_mailing_test.py
+++ b/tests/utils_mailing_test.py
@@ -867,9 +867,8 @@ def test_make_payment_transaction_email():
     # Then
     assert email["From"] == {"Email": "passculture@beta.gouv.fr",
                              "Name": "pass Culture Pro"}
-    assert email["To"] == [{"Email": "passculture-dev@beta.gouv.fr",
-                            "Name": "Compta pass Culture"}]
     assert email["Subject"] == "Virements pass Culture Pro - 2018-10-15"
+    assert email["Html-part"] == ""
     assert email["Attachments"] == [{"ContentType": "text/xml",
                                      "Filename": "transaction_banque_de_france_20181015.xml",
                                      "Base64Content": b'PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48RG9j'
@@ -942,7 +941,6 @@ def test_make_venue_validation_email(app):
     # Then
     assert email["FromEmail"] == "passculture@beta.gouv.fr"
     assert email["FromName"] == "pass Culture"
-    assert email["To"] == "passculture@beta.gouv.fr"
     assert email["Subject"] == "{} - rattachement de lieu pro à valider : {}".format(venue.departementCode, venue.name)
     email_html = remove_whitespaces(email['Html-part'])
     parsed_email = BeautifulSoup(email_html, 'html.parser')

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -126,8 +126,7 @@ def write_object_validation_email(offerer, user_offerer, get_by_siren=api_entrep
         'FromEmail': 'passculture@beta.gouv.fr',
         'Subject': "%s - inscription / rattachement PRO à valider : %s" % (
             user_offerer.user.departementCode, offerer.name),
-        'Html-part': email_html,
-        'To': 'passculture@beta.gouv.fr' if feature_send_mail_to_users_enabled() else 'passculture-dev@beta.gouv.fr'
+        'Html-part': email_html
     }
 
 
@@ -223,7 +222,7 @@ def make_reset_password_email(user, app_origin_url):
         'FromEmail': 'passculture@beta.gouv.fr' if feature_send_mail_to_users_enabled() else 'passculture-dev@beta.gouv.fr',
         'Subject': 'Réinitialisation de votre mot de passe',
         'Html-part': email_html,
-        'To': user.email
+        'To': [user.email]
     }
 
 
@@ -261,7 +260,6 @@ def make_venue_validation_email(venue):
     return {
         'FromEmail': 'passculture@beta.gouv.fr',
         'FromName': 'pass Culture',
-        'To': 'passculture@beta.gouv.fr',
         'Subject': '{} - rattachement de lieu pro à valider : {}'.format(venue.departementCode, venue.name),
         'Html-part': html
     }
@@ -323,8 +321,6 @@ def make_payment_transaction_email(xml: str) -> dict:
     return {
         'From': {"Email": "passculture@beta.gouv.fr",
                  "Name": "pass Culture Pro"},
-        'To': [{"Email": "passculture-dev@beta.gouv.fr",
-                "Name": "Compta pass Culture"}],
         'Subject': "Virements pass Culture Pro - {}".format(datetime.strftime(now, "%Y-%m-%d")),
         'Attachments': [{"ContentType": "text/xml",
                          "Filename": "transaction_banque_de_france_{}.xml".format(datetime.strftime(now, "%Y%m%d")),

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -339,7 +339,7 @@ def make_venue_validation_confirmation_email(venue):
     }
 
 
-def edit_email_html_part_and_recipients(email_html_part, recipients):
+def compute_email_html_part_and_recipients(email_html_part, recipients):
     recipients_string = ", ".join(recipients)
     if feature_send_mail_to_users_enabled():
         email_to = recipients_string

--- a/utils/mailing.py
+++ b/utils/mailing.py
@@ -219,10 +219,9 @@ def make_reset_password_email(user, app_origin_url):
 
     return {
         'FromName': 'Pass Culture',
-        'FromEmail': 'passculture@beta.gouv.fr' if feature_send_mail_to_users_enabled() else 'passculture-dev@beta.gouv.fr',
+        'FromEmail': 'passculture@beta.gouv.fr',
         'Subject': 'Réinitialisation de votre mot de passe',
         'Html-part': email_html,
-        'To': [user.email]
     }
 
 
@@ -341,12 +340,11 @@ def make_venue_validation_confirmation_email(venue):
 
 
 def edit_email_html_part_and_recipients(email_html_part, recipients):
+    recipients_string = ", ".join(recipients)
     if feature_send_mail_to_users_enabled():
-        email_to = ", ".join(recipients)
+        email_to = recipients_string
     else:
-        email_html_part = ('<p>This is a test (ENV=%s). In production, email would have been sent to : ' % ENV) \
-                          + ", ".join(recipients) \
-                          + '</p>' + email_html_part
+        email_html_part = '<p>This is a test (ENV={environment}). In production, email would have been sent to : {recipients}</p>{html_part}'.format(environment=ENV, recipients=recipients_string, html_part=email_html_part)
         email_to = 'passculture-dev@beta.gouv.fr'
     return email_html_part, email_to
 


### PR DESCRIPTION
venue validation email is sent to passculture-dev when feature_send_user_emails disabled, test this for venue validation confirmation email too