### PR TITLE
453 [POST PO REVIEW FIX] prevent insert_tuto_mediation to create already existing tuto mediation

### DIFF
--- a/recommendations_engine/recommendations.py
+++ b/recommendations_engine/recommendations.py
@@ -54,7 +54,7 @@ def create_recommendations_for_discovery(limit=3, user=None, coords=None):
             tuto_mediation_index = recommendation_count \
                                         + index \
                                         + inserted_tuto_mediations
-            create_tuto_mediation_if_not_exists_for_user(
+            create_tuto_mediation_if_non_existent_for_user(
                 user,
                 tuto_mediations_by_index[tuto_mediation_index]
             )
@@ -63,7 +63,7 @@ def create_recommendations_for_discovery(limit=3, user=None, coords=None):
     return recommendations
 
 
-def create_tuto_mediation_if_not_exists_for_user(user, tuto_mediation):
+def create_tuto_mediation_if_non_existent_for_user(user, tuto_mediation):
 
     already_existing_tuto_recommendation = Recommendation.query\
         .filter_by(mediation=tuto_mediation, user=user)\

--- a/repository/recommendation_queries.py
+++ b/repository/recommendation_queries.py
@@ -17,9 +17,9 @@ from utils.human_ids import dehumanize
 def find_unseen_tutorials_for_user(seen_recommendation_ids, user):
     return Recommendation.query.join(Mediation) \
         .filter(
-        (Mediation.tutoIndex != None)
-        & (Recommendation.user == user)
-        & ~Recommendation.id.in_(seen_recommendation_ids)) \
+            (Mediation.tutoIndex != None)
+            & (Recommendation.user == user)
+            & ~Recommendation.id.in_(seen_recommendation_ids)) \
         .order_by(Mediation.tutoIndex) \
         .all()
 

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -1,4 +1,3 @@
-""" user mediations routes """
 from random import shuffle
 
 from flask import current_app as app, jsonify, request
@@ -70,14 +69,17 @@ def put_recommendations():
     mediation_id = dehumanize(request.args.get('mediationId'))
 
     try:
-        requested_recommendation = give_requested_recommendation_to_user(current_user, offer_id, mediation_id)
+        requested_recommendation = give_requested_recommendation_to_user(
+            current_user,
+            offer_id,
+            mediation_id
+        )
     except OfferNotFoundException:
         return "Offer or mediation not found", 404
 
     logger.info('(special) requested_recommendation %s' % (requested_recommendation,))
 
     # we get more read+unread recos than needed in case we can't make enough new recos
-
     unread_recos = find_all_unread_recommendations(current_user, seen_recommendation_ids)
     read_recos = find_all_read_recommendations(current_user, seen_recommendation_ids)
 

--- a/scripts/sandbox.py
+++ b/scripts/sandbox.py
@@ -1,4 +1,3 @@
-""" sandbox script """
 # -*- coding: utf-8 -*-
 from pprint import pprint
 import traceback


### PR DESCRIPTION
L'apparition des cartes tutos apres une deuxieme connexion n'etait pas encore au point.

Au poins d'ailleurs que Nicolas voyait sur testing que ca ne marchait pas.

Et voici je pense la raison, surement fixée ici pour flask et y aura aussi surement un fix sur webapp complementaire.

A la première connexion /decouverte de l'appli webapp, je ne sais pas bien encore si on peut y faire grand chose (à voir un fix est possible), l'appli frontend appelle DEUX fois en moins de qqes ms la route PUT /recommendations. ... Du coup on passe deux fois quasi en meme temps dans create_recommendations_for_discovery qui pour les deux appels considere que recommendation_count = 0...

Du coup on passait deux dans inser_tuto_mediations => on cree en double les cartes tutos.
Du coup on a beau dire qu'on a lue les deux cartes tuto du debut, il restait les deux autres doublons pas lues.

Donc en premier fixe cote flask, je transforme  inser_tuto_mediations en create_tuto_mediation_if_not_exists_for_user pour etre sur de ne pas creer en doublon les tutos.

Maintenant je vais voir cote webapp comment empecher un double appel en PUT /recommendations.







