### PR TITLE
(PC 453) added recommendations/read route

### DIFF
--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -49,6 +49,17 @@ def patch_recommendation(recommendationId):
     return jsonify(_serialize_recommendation(recommendation)), 200
 
 
+@app.route('/recommendations/read', methods=['PUT'])
+@login_required
+@expect_json_data
+def put_read_recommendations():
+
+    read_recommendations = request.json['readRecommendations']
+
+    update_read_recommendations(read_recommendations)
+
+    return jsonify(read_recommendations), 200
+
 @app.route('/recommendations', methods=['PUT'])
 @login_required
 @expect_json_data

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -54,11 +54,14 @@ def patch_recommendation(recommendationId):
 @expect_json_data
 def put_read_recommendations():
 
-    read_recommendations = request.json['readRecommendations']
+    update_read_recommendations(request.json)
 
-    update_read_recommendations(read_recommendations)
+    read_recommendation_ids = [dehumanize(reco['id']) for reco in request.json]
+    read_recommendations = Recommendation.query.filter(
+        Recommendation.id.in_(read_recommendation_ids)
+    ).all()
 
-    return jsonify(read_recommendations), 200
+    return jsonify(_serialize_recommendations(read_recommendations)), 200
 
 @app.route('/recommendations', methods=['PUT'])
 @login_required

--- a/tests/routes_recommendations_test.py
+++ b/tests/routes_recommendations_test.py
@@ -61,7 +61,7 @@ def test_put_read_recommendations(app):
     )
 
     # When
-    read_recommendations = [
+    read_recommendation_data = [
         {
             "dateRead": "2018-12-17T15:59:11.689000Z",
             "id": humanize(recommendation1.id)
@@ -75,14 +75,13 @@ def test_put_read_recommendations(app):
     read_recommendations_url = '{}/read'.format(RECOMMENDATION_URL)
     response = req_with_auth('test@email.com', 'P@55w0rd')\
                          .put(read_recommendations_url,
-                              json=read_recommendations)
+                              json=read_recommendation_data)
 
     # Then
-    recommendations = [r for r in response.json()]
-    assert len(recommendations) == 2
-    assert recommendation1.dateRead is not None
-    assert recommendation2.dateRead is not None
-    assert recommendation3.dateRead is None
+    read_recommendations = [r for r in response.json()]
+    assert len(read_recommendations) == 2
+    assert read_recommendations[0]['dateRead'] == "2018-12-17T15:59:11.689000Z"
+    assert read_recommendations[1]['dateRead'] == "2018-12-17T15:59:14.689000Z"
 
 
 @clean_database


### PR DESCRIPTION
... On a besoin de cette mini route au moment du signout d'un user jeune sur webapp.

Avant de signout il doit put les cartes qu'il a lues.
C'est vrai qu 'on pourrait le faire deja avec la route PUT recommendations, mais je trouve que ca serait  un peu lourd comme appel pour juste ça.