### PR TITLE
(PC-1395) [MES prefixing] fix de la recherche des offres pour la routes /offers dans pro 

### DIFF
--- a/recommendations_engine/recommendations.py
+++ b/recommendations_engine/recommendations.py
@@ -190,7 +190,7 @@ def get_recommendation_search_params(kwargs):
         search_params['page'] = int(kwargs['page'])
 
     if 'keywords' in kwargs and kwargs['keywords']:
-        search_params['keywords'] = kwargs['keywords']
+        search_params['keywords_string'] = kwargs['keywords']
 
     if 'categories' in kwargs and kwargs['categories']:
         type_sublabels = kwargs['categories']

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -201,7 +201,7 @@ def find_offers_with_filter_parameters(
 
     if not user.isAdmin:
         query = filter_query_where_user_is_user_offerer_and_is_validated(
-            query.reset_joinpoint(),
+            query,
             user
         )
 

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -196,8 +196,6 @@ def find_offers_with_filter_parameters(
             keywords_string
         )
     else:
-        # We need to do the join if it was not done
-        # during the keywords filter time
         query = query.join(Venue).join(Offerer)
 
     if offerer_id is not None:

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -183,17 +183,16 @@ def get_offers_for_recommendations_search(
 
 
 def find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(
-        offerer_id,
-        venue,
-        venue_id,
         user,
-        keywords_string
+        offerer_id=None,
+        venue_id=None,
+        keywords_string=None
 ):
     query = Offer.query
 
 
     if venue_id is not None:
-        query = query.filter_by(venue=venue)
+        query = query.filter_by(venueId=venue_id)
 
     if offerer_id is not None or not user.isAdmin or keywords_string is not None:
         query = query.join(Venue) \
@@ -201,6 +200,7 @@ def find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rig
 
     if offerer_id is not None:
         query = query.filter_by(id=offerer_id)
+
     elif not user.isAdmin:
         query = filter_query_where_user_is_user_offerer_and_is_validated(query, user)
 

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -195,6 +195,10 @@ def find_offers_with_filter_parameters(
             query,
             keywords_string
         )
+    else:
+        # We need to do the join if it was not done
+        # during the keywords filter time
+        query = query.join(Venue).join(Offerer)
 
     if offerer_id is not None:
         query = query.filter_by(managingOffererId=offerer_id)

--- a/repository/user_offerer_queries.py
+++ b/repository/user_offerer_queries.py
@@ -13,7 +13,8 @@ def filter_query_where_user_is_user_offerer_and_is_validated(query, user):
     return query \
         .join(UserOfferer) \
         .filter_by(user=user) \
-        .filter_by(validationToken=None)
+        .filter_by(validationToken=None) \
+        .reset_joinpoint()
 
 
 def filter_query_where_user_is_user_offerer_and_is_not_validated(query, user):

--- a/repository/user_offerer_queries.py
+++ b/repository/user_offerer_queries.py
@@ -13,8 +13,7 @@ def filter_query_where_user_is_user_offerer_and_is_validated(query, user):
     return query \
         .join(UserOfferer) \
         .filter_by(user=user) \
-        .filter_by(validationToken=None) \
-        .reset_joinpoint()
+        .filter_by(validationToken=None)
 
 
 def filter_query_where_user_is_user_offerer_and_is_not_validated(query, user):

--- a/routes/offerers.py
+++ b/routes/offerers.py
@@ -35,11 +35,14 @@ def list_offerers():
     if not current_user.isAdmin:
         if only_validated_offerers:
             query = filter_query_where_user_is_user_offerer_and_is_validated(
-                query.join(Venue).join(Offerer),
+                query,
                 current_user
             )
         else:
-            query = filter_query_where_user_is_user_offerer_and_is_not_validated(query, current_user)
+            query = filter_query_where_user_is_user_offerer_and_is_not_validated(
+                query,
+                current_user
+            )
 
     keywords = request.args.get('keywords')
     if keywords is not None:

--- a/routes/offerers.py
+++ b/routes/offerers.py
@@ -4,7 +4,7 @@ from flask_login import current_user, login_required
 from domain.admin_emails import maybe_send_offerer_validation_email
 from domain.discard_pc_objects import invalidate_recommendations_if_deactivating_object
 from domain.reimbursement import find_all_booking_reimbursement
-from models import Offerer, PcObject, RightsType
+from models import Offerer, PcObject, RightsType, Venue
 from models.venue import create_digital_venue
 from repository.booking_queries import find_offerer_bookings
 from repository.offerer_queries import find_all_recommendations_for_offerer,\
@@ -34,7 +34,10 @@ def list_offerers():
 
     if not current_user.isAdmin:
         if only_validated_offerers:
-            query = filter_query_where_user_is_user_offerer_and_is_validated(query, current_user)
+            query = filter_query_where_user_is_user_offerer_and_is_validated(
+                query.join(Venue).join(Offerer),
+                current_user
+            )
         else:
             query = filter_query_where_user_is_user_offerer_and_is_not_validated(query, current_user)
 

--- a/routes/offers.py
+++ b/routes/offers.py
@@ -10,7 +10,8 @@ from models import ApiErrors, Offer, PcObject, Recommendation, \
     RightsType, Venue
 from models.db import db
 from repository import venue_queries, offer_queries
-from repository.offer_queries import find_activation_offers
+from repository.offer_queries import find_activation_offers, \
+                                     find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights
 from utils.human_ids import dehumanize
 from utils.includes import OFFER_INCLUDES
 from utils.rest import ensure_current_user_has_rights, \
@@ -30,7 +31,7 @@ def list_offers():
     check_venue_exists_when_requested(venue, venue_id)
     check_user_has_rights_for_query(offerer_id, venue, venue_id)
 
-    query = offer_queries.find_by_venue_id_or_offerer_id_and_search_terms_offers_where_user_has_rights(
+    query = find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(
         offerer_id,
         venue,
         venue_id,

--- a/routes/offers.py
+++ b/routes/offers.py
@@ -11,7 +11,7 @@ from models import ApiErrors, Offer, PcObject, Recommendation, \
 from models.db import db
 from repository import venue_queries, offer_queries
 from repository.offer_queries import find_activation_offers, \
-                                     find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights
+                                     find_offers_with_filter_parameters
 from utils.human_ids import dehumanize
 from utils.includes import OFFER_INCLUDES
 from utils.rest import ensure_current_user_has_rights, \
@@ -31,7 +31,7 @@ def list_offers():
     check_venue_exists_when_requested(venue, venue_id)
     check_user_has_rights_for_query(offerer_id, venue, venue_id)
 
-    query = find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(
+    query = find_offers_with_filter_parameters(
         current_user,
         offerer_id=offerer_id,
         venue_id=venue_id,

--- a/routes/offers.py
+++ b/routes/offers.py
@@ -32,11 +32,10 @@ def list_offers():
     check_user_has_rights_for_query(offerer_id, venue, venue_id)
 
     query = find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(
-        offerer_id,
-        venue,
-        venue_id,
         current_user,
-        request.args.get('keywords')
+        offerer_id=offerer_id,
+        venue_id=venue_id,
+        keywords_string=request.args.get('keywords')
     )
 
     return handle_rest_get_list(Offer,

--- a/tests/repository_offer_queries_test.py
+++ b/tests/repository_offer_queries_test.py
@@ -214,7 +214,7 @@ def test_get_offers_for_recommendations_search_with_several_partial_keywords(app
     PcObject.check_and_save(event_ko_stock, thing_ok_stock, thing_ko_stock)
 
     # When
-    offers = get_offers_for_recommendations_search(keywords='renc michel')
+    offers = get_offers_for_recommendations_search(keywords_string='renc michel')
 
     # Then
     assert thing_ok_offer in offers

--- a/tests/repository_offer_queries_test.py
+++ b/tests/repository_offer_queries_test.py
@@ -401,7 +401,7 @@ def test_find_offers_with_filter_parameters(app):
     user = create_user(email='offerer@email.com')
     offerer1 = create_offerer(siren='123456789')
     offerer2 = create_offerer(siren='987654321')
-    offerer3 = create_offerer(siren='123456780')
+    ko_offerer3 = create_offerer(siren='123456780')
     user_offerer1 = create_user_offerer(user, offerer1)
     user_offerer2 = create_user_offerer(user, offerer2)
 
@@ -412,13 +412,13 @@ def test_find_offers_with_filter_parameters(app):
     offerer = create_offerer()
     venue1 = create_venue(offerer1, name='Bataclan', city='Paris', siret=offerer.siren + '12345')
     venue2 = create_venue(offerer2, name='Librairie la Rencontre', city='Saint Denis', siret=offerer.siren + '54321')
-    venue3 = create_venue(offerer3, name='Une librairie du méchant concurrent gripsou', city='Saint Denis', siret=offerer3.siren + '54321')
+    ko_venue3 = create_venue(ko_offerer3, name='Une librairie du méchant concurrent gripsou', city='Saint Denis', siret=offerer3.siren + '54321')
     ok_offer1 = create_event_offer(venue1, ok_event1)
     ko_offer2 = create_event_offer(venue1, event2)
-    ko_offer3 = create_thing_offer(venue3, thing1)
+    ko_offer3 = create_thing_offer(ko_venue3, thing1)
     ko_offer4 = create_thing_offer(venue2, thing2)
     PcObject.check_and_save(
-        user_offerer1, user_offerer2, offerer3,
+        user_offerer1, user_offerer2, ko_offerer3,
         ok_offer1, ko_offer2, ko_offer3, ko_offer4
     )
 

--- a/tests/repository_offer_queries_test.py
+++ b/tests/repository_offer_queries_test.py
@@ -6,7 +6,7 @@ from models import Thing, PcObject, Event
 from models.offer_type import EventType, ThingType
 from repository.offer_queries import departement_or_national_offers, \
                                      find_activation_offers, \
-                                     find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights, \
+                                     find_offers_with_filter_parameters, \
                                      get_offers_for_recommendations_search, \
                                      get_active_offers_by_type
 from tests.conftest import clean_database
@@ -397,7 +397,7 @@ def test_find_activation_offers_returns_activation_offers_with_future_booking_li
 
 @clean_database
 @pytest.mark.standalone
-def test_find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(app):
+def test_find_offers_with_filter_parameters(app):
     user = create_user(email='offerer@email.com')
     offerer1 = create_offerer(siren='123456789')
     offerer2 = create_offerer(siren='987654321')
@@ -423,7 +423,7 @@ def test_find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_ha
     )
 
     # when
-    offers = find_by_venue_id_or_offerer_id_and_keywords_string_offers_where_user_has_rights(
+    offers = find_offers_with_filter_parameters(
         user,
         venue_id=venue1.id,
         keywords_string='Jacq Rencon'

--- a/tests/repository_offer_queries_test.py
+++ b/tests/repository_offer_queries_test.py
@@ -412,7 +412,7 @@ def test_find_offers_with_filter_parameters(app):
     offerer = create_offerer()
     venue1 = create_venue(offerer1, name='Bataclan', city='Paris', siret=offerer.siren + '12345')
     venue2 = create_venue(offerer2, name='Librairie la Rencontre', city='Saint Denis', siret=offerer.siren + '54321')
-    ko_venue3 = create_venue(ko_offerer3, name='Une librairie du méchant concurrent gripsou', city='Saint Denis', siret=offerer3.siren + '54321')
+    ko_venue3 = create_venue(ko_offerer3, name='Une librairie du méchant concurrent gripsou', city='Saint Denis', siret=ko_offerer3.siren + '54321')
     ok_offer1 = create_event_offer(venue1, ok_event1)
     ko_offer2 = create_event_offer(venue1, event2)
     ko_offer3 = create_thing_offer(ko_venue3, thing1)

--- a/tests/routes_recommendations_get_test.py
+++ b/tests/routes_recommendations_get_test.py
@@ -43,7 +43,9 @@ def test_get_recommendations_works_only_when_logged_in():
 @pytest.mark.standalone
 def test_get_recommendations_returns_one_recommendation_found_from_search_with_matching_case(app):
     # given
-    search = "keywords=Training"
+    keywords_string = "Training"
+    location_search = "keywords={}".format(keywords_string)
+    search = "keywords_string={}".format(keywords_string)
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -54,19 +56,19 @@ def test_get_recommendations_returns_one_recommendation_found_from_search_with_m
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     recommendations = response.json()
     assert 'Training' in recommendations[0]['offer']['eventOrThing']['name']
-    assert recommendations[0]['search'] == 'keywords=Training'
+    assert recommendations[0]['search'] == search
 
 
 @clean_database
 @pytest.mark.standalone
 def test_get_recommendations_returns_one_recommendation_from_search_by_type(app):
     # given
-    search = "categories=Applaudir"
+    location_search = "categories=Applaudir"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -77,7 +79,7 @@ def test_get_recommendations_returns_one_recommendation_from_search_by_type(app)
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     assert len(response.json()) == 1
@@ -87,7 +89,9 @@ def test_get_recommendations_returns_one_recommendation_from_search_by_type(app)
 @pytest.mark.standalone
 def test_get_recommendations_returns_one_recommendation_found_from_search_ignoring_case(app):
     # given
-    search = "keywords=rencontres"
+    keywords_string = "rencontres"
+    location_search = "keywords={}".format(keywords_string)
+    search = "keywords_string={}".format(keywords_string)
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -102,19 +106,21 @@ def test_get_recommendations_returns_one_recommendation_found_from_search_ignori
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     recommendations = response.json()
     assert 'Rencontres' in recommendations[0]['offer']['eventOrThing']['name']
-    assert recommendations[0]['search'] == 'keywords=rencontres'
+    assert recommendations[0]['search'] == search
 
 
 @clean_database
 @pytest.mark.standalone
 def test_get_recommendations_with_double_and_trailing_whitespaces_returns_one_recommendation(app):
     # given
-    search = "keywords= rencontres avec auteurs "
+    keywords_string = " rencontres avec auteurs "
+    location_search = "keywords={}".format(keywords_string)
+    search = "keywords_string={}".format(keywords_string)
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -127,7 +133,7 @@ def test_get_recommendations_with_double_and_trailing_whitespaces_returns_one_re
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     recommendations = response.json()
@@ -138,7 +144,9 @@ def test_get_recommendations_with_double_and_trailing_whitespaces_returns_one_re
 @pytest.mark.standalone
 def test_get_recommendations_returns_one_recommendation_found_from_partial_search(app):
     # given
-    search = "keywords=rencon"
+    keywords_string = "rencon"
+    location_search = "keywords={}".format(keywords_string)
+    search = "keywords_string={}".format(keywords_string)
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -151,19 +159,21 @@ def test_get_recommendations_returns_one_recommendation_found_from_partial_searc
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     recommendations = response.json()
     assert 'Rencontres' in recommendations[0]['offer']['eventOrThing']['name']
-    assert recommendations[0]['search'] == 'keywords=rencon'
+    assert recommendations[0]['search'] == search
 
 
 @clean_database
 @pytest.mark.standalone
 def test_get_recommendations_does_not_return_recommendations_of_offers_with_soft_deleted_stocks(app):
     # given
-    search = 'keywords=rencontres'
+    keywords_string = 'rencontres'
+    location_search = 'keywords={}'.format(keywords_string)
+    search = 'keywords={}'.format(keywords_string)
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -186,7 +196,7 @@ def test_get_recommendations_does_not_return_recommendations_of_offers_with_soft
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     assert len(response.json()) == 1
@@ -196,7 +206,7 @@ def test_get_recommendations_does_not_return_recommendations_of_offers_with_soft
 @pytest.mark.standalone
 def test_get_recommendations_returns_two_recommendation_from_filter_by_two_types(app):
     # given
-    search = "categories=Applaudir%2CRegarder"
+    location_search = "categories=Applaudir%2CRegarder"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -210,7 +220,7 @@ def test_get_recommendations_returns_two_recommendation_from_filter_by_two_types
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     assert len(response.json()) == 2
@@ -220,7 +230,7 @@ def test_get_recommendations_returns_two_recommendation_from_filter_by_two_types
 @pytest.mark.standalone
 def test_get_recommendations_returns_all_recommendations_from_filter_by_all_types(app):
     # given
-    search = "categories=%25C3%2589couter%2CApplaudir%2CJouer%2CLire%2CPratiquer%2CRegarder%2CRencontrer"
+    location_search = "categories=%25C3%2589couter%2CApplaudir%2CJouer%2CLire%2CPratiquer%2CRegarder%2CRencontrer"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -237,17 +247,16 @@ def test_get_recommendations_returns_all_recommendations_from_filter_by_all_type
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # when
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # then
     assert len(response.json()) == 3
-
 
 @clean_database
 @pytest.mark.standalone
 def test_get_recommendations_returns_recommendations_in_date_range_from_search_by_date(app):
     # Given
-    search = "date=" + strftime(now) + "&days=0-1"
+    location_search = "date=" + strftime(now) + "&days=0-1"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -261,7 +270,7 @@ def test_get_recommendations_returns_recommendations_in_date_range_from_search_b
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     recommendations = response.json()
@@ -273,7 +282,7 @@ def test_get_recommendations_returns_recommendations_in_date_range_from_search_b
 @pytest.mark.standalone
 def test_get_recommendations_returns_no_recommendation_when_no_stock_in_date_range(app):
     # Given
-    search = "date=" + strftime(ten_days_from_now) + "&days=0-1"
+    location_search = "date=" + strftime(ten_days_from_now) + "&days=0-1"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -287,7 +296,7 @@ def test_get_recommendations_returns_no_recommendation_when_no_stock_in_date_ran
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     assert len(response.json()) == 0
@@ -297,8 +306,7 @@ def test_get_recommendations_returns_no_recommendation_when_no_stock_in_date_ran
 @pytest.mark.standalone
 def test_get_recommendations_returns_two_recommendations_from_search_by_date_and_type(app):
     # Given
-    search = "categories=Lire%2CRegarder&date=" + strftime(now) + "&days=0-1"
-    search = "categories=Lire%2CRegarder%2CActivation"
+    location_search = "categories=Lire%2CRegarder&date=" + strftime(now) + "&days=0-1"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -320,7 +328,7 @@ def test_get_recommendations_returns_two_recommendations_from_search_by_date_and
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     assert len(response.json()) == 2
@@ -333,7 +341,7 @@ def test_get_recommendations_returns_two_recommendations_from_search_by_date_and
 @pytest.mark.standalone
 def test_get_recommendations_returns_recommendations_from_search_by_date_and_type_except_if_it_is_activation_type(app):
     # Given
-    search = "categories=Lire%2CRegarder%2CActivation&date=" + strftime(now) + "&days=0-1"
+    location_search = "categories=Lire%2CRegarder%2CActivation&date=" + strftime(now) + "&days=0-1"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -355,7 +363,7 @@ def test_get_recommendations_returns_recommendations_from_search_by_date_and_typ
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     assert len(response.json()) == 2
@@ -367,7 +375,7 @@ def test_get_recommendations_returns_recommendations_from_search_by_date_and_typ
 @pytest.mark.standalone
 def test_get_recommendations_returns_recommendation_from_search_by_type_including_activation_type(app):
     # Given
-    search = "categories=Activation%2CLire%2CRegarder"
+    location_search = "categories=Activation%2CLire%2CRegarder"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -383,7 +391,7 @@ def test_get_recommendations_returns_recommendation_from_search_by_type_includin
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     assert len(response.json()) == 2
@@ -395,7 +403,7 @@ def test_get_recommendations_returns_recommendation_from_search_by_type_includin
 @pytest.mark.standalone
 def test_get_recommendations_returns_no_recommendations_from_search_by_date_and_type_and_pagination_not_in_range(app):
     # Given
-    search = "categories=Lire%2CRegarder&date=" + strftime(now) + "&days=0-1&page=2"
+    location_search = "categories=Lire%2CRegarder&date=" + strftime(now) + "&days=0-1&page=2"
     user = create_user(email='test@email.com', password='P@55w0rd')
     offerer = create_offerer()
     venue = create_venue(offerer)
@@ -414,7 +422,7 @@ def test_get_recommendations_returns_no_recommendations_from_search_by_date_and_
     auth_request = req_with_auth(user.email, user.clearTextPassword)
 
     # When
-    response = auth_request.get(RECOMMENDATION_URL + '?%s' % search)
+    response = auth_request.get(RECOMMENDATION_URL + '?%s' % location_search)
 
     # Then
     assert response.status_code == 200


### PR DESCRIPTION
Le merge de pc-1364 (api) a cassé la recherche des offres sur pro.

On aurait vu ce problème lors de la MES, mais je fais tout de suite ici le fix pour eviter de l'avoir le hour même de la MES. 