### PR TITLE
PC 1506 add parsing method to remove url chars, still need to be impr…

### DIFF
--- a/domain/keywords.py
+++ b/domain/keywords.py
@@ -1,8 +1,11 @@
 from nltk.corpus import stopwords
-from nltk.tokenize import word_tokenize
+# from nltk.tokenize import word_tokenize
 from sqlalchemy import and_, func, TEXT
 from sqlalchemy.sql.expression import cast, or_
 from sqlalchemy.sql.functions import coalesce
+
+from utils.string_processing import tokenize_for_search
+
 
 LANGUAGE = 'french'
 STOP_WORDS = set(stopwords.words(LANGUAGE))
@@ -14,10 +17,11 @@ def create_tsvector(*args):
         exp += ' ' + e
     return func.to_tsvector(LANGUAGE+'_unaccent', exp)
 
-
 def get_ts_queries_from_keywords_string(keywords_string):
+    keywords = tokenize_for_search(keywords_string)
 
-    keywords = word_tokenize(keywords_string)
+    keywords = filter(lambda k: len(k) > 1, keywords)
+
     keywords_without_stop_words = [
         keyword
         for keyword in keywords

--- a/domain/keywords.py
+++ b/domain/keywords.py
@@ -1,10 +1,9 @@
 from nltk.corpus import stopwords
-# from nltk.tokenize import word_tokenize
 from sqlalchemy import and_, func, TEXT
 from sqlalchemy.sql.expression import cast, or_
 from sqlalchemy.sql.functions import coalesce
 
-from utils.string_processing import tokenize_for_search
+from utils.string_processing import remove_single_letters_for_search, tokenize_for_search
 
 
 LANGUAGE = 'french'
@@ -19,12 +18,11 @@ def create_tsvector(*args):
 
 def get_ts_queries_from_keywords_string(keywords_string):
     keywords = tokenize_for_search(keywords_string)
-
-    keywords = filter(lambda k: len(k) > 1, keywords)
+    keywords_without_single_letter = remove_single_letters_for_search(keywords)
 
     keywords_without_stop_words = [
         keyword
-        for keyword in keywords
+        for keyword in keywords_without_single_letter
         if keyword.lower() not in STOP_WORDS
     ]
 

--- a/recommendations_engine/recommendations.py
+++ b/recommendations_engine/recommendations.py
@@ -11,6 +11,7 @@ from repository import offer_queries
 from repository.offer_queries import get_offers_for_recommendations_search, find_searchable_offer
 from repository.recommendation_queries import find_recommendations_for_user_matching_offers_and_search
 from utils.logger import logger
+from utils.string_processing import parse_string
 
 
 class OfferNotFoundException(Exception):
@@ -159,6 +160,7 @@ def create_recommendations_for_search(user, **kwargs):
     offers = get_offers_for_recommendations_search(**kwargs)
     offer_ids = [offer.id for offer in offers]
     search = get_search(kwargs)
+
     existing_recommendations = find_recommendations_for_user_matching_offers_and_search(user.id, offer_ids, search)
     offer_ids_with_already_created_recommendations = [reco.offerId for reco in existing_recommendations]
     recommendations = []
@@ -189,7 +191,7 @@ def get_recommendation_search_params(request_args: dict) -> dict:
         search_params['page'] = int(request_args['page'])
 
     if 'keywords' in request_args and request_args['keywords']:
-        search_params['keywords_string'] = request_args['keywords']
+        search_params['keywords_string'] = parse_string(request_args['keywords'])
 
     if 'categories' in request_args and request_args['categories']:
         type_sublabels = request_args['categories']

--- a/recommendations_engine/recommendations.py
+++ b/recommendations_engine/recommendations.py
@@ -11,8 +11,6 @@ from repository import offer_queries
 from repository.offer_queries import get_offers_for_recommendations_search, find_searchable_offer
 from repository.recommendation_queries import find_recommendations_for_user_matching_offers_and_search
 from utils.logger import logger
-from utils.string_processing import parse_string
-
 
 class OfferNotFoundException(Exception):
     pass
@@ -191,7 +189,7 @@ def get_recommendation_search_params(request_args: dict) -> dict:
         search_params['page'] = int(request_args['page'])
 
     if 'keywords' in request_args and request_args['keywords']:
-        search_params['keywords_string'] = parse_string(request_args['keywords'])
+        search_params['keywords_string'] = request_args['keywords']
 
     if 'categories' in request_args and request_args['categories']:
         type_sublabels = request_args['categories']

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -29,7 +29,6 @@ from utils.rest import expect_json_data
 @login_required
 def list_recommendations():
     search_params = get_recommendation_search_params(request.args)
-    
     recommendations = create_recommendations_for_search(
         current_user,
         **search_params

--- a/tests/domain_keywords_test.py
+++ b/tests/domain_keywords_test.py
@@ -12,7 +12,7 @@ def test_get_ts_queries_from_keywords_string_parses_keywords_string_into_list_of
     keywords_result = get_ts_queries_from_keywords_string(keywords_string)
 
     # then
-    assert keywords_result == ['PNL:*', 'chante:*', 'Marx:*']
+    assert keywords_result == ['pnl:*', 'chante:*', 'marx:*']
 
 
 @pytest.mark.standalone
@@ -24,7 +24,7 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
     keywords_result = get_ts_queries_from_keywords_string(keywords_string)
 
     # then
-    assert keywords_result == ['PNL:*', 'chante:*', 'Marx:*']
+    assert keywords_result == ['pnl:*', 'chante:*', 'marx:*']
 
 @pytest.mark.standalone
 def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_stop_words():
@@ -35,7 +35,7 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
     keywords_result = get_ts_queries_from_keywords_string(keywords_string)
 
     # then
-    assert keywords_result == ['PNL:*', 'chante:*', 'Marx:*']
+    assert keywords_result == ['pnl:*', 'chante:*', 'marx:*']
 
 @pytest.mark.standalone
 def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_stop_words_with_capital_letter():
@@ -47,3 +47,14 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
 
     # then
     assert keywords_result == ['lit:*', 'sous:*', 'rivière:*']
+
+@pytest.mark.standalone
+def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_words_with_less_than_one_char():
+    # given
+    keywords_string = "Læetitia a mangé's'"
+
+    # when
+    keywords_result = get_ts_queries_from_keywords_string(keywords_string)
+
+    # then
+    assert keywords_result == ['læetitia:*', 'mangé:*']

--- a/tests/domain_keywords_test.py
+++ b/tests/domain_keywords_test.py
@@ -29,7 +29,7 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
 @pytest.mark.standalone
 def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_stop_words():
     # given
-    keywords_string = 'PNL chante avec Marx'
+    keywords_string = 'PNL  chante avec Marx'
 
     # when
     keywords_result = get_ts_queries_from_keywords_string(keywords_string)
@@ -48,8 +48,20 @@ def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_s
     # then
     assert keywords_result == ['lit:*', 'sous:*', 'rivière:*']
 
+    @pytest.mark.standalone
+    def test_get_ts_queries_from_keywords_url_parses_keywords_string_ignoring_special_chars():
+        # given
+        keywords_string = "http://www.test.com"
+
+        # when
+        keywords_result = get_ts_queries_from_keywords_string(keywords_string)
+
+        # then
+        assert keywords_result == ['http:*', 'www:*', 'test:*', 'com:*']
+
+
 @pytest.mark.standalone
-def test_get_ts_queries_from_keywords_string_with_double_space_parses_keywords_string_ignoring_words_with_less_than_one_char():
+def test_get_ts_queries_from_keywords_string_with_coma_parses_keywords_string_ignoring_words_with_less_than_one_char():
     # given
     keywords_string = "Læetitia a mangé's'"
 

--- a/tests/routes/recommendations_get_test.py
+++ b/tests/routes/recommendations_get_test.py
@@ -184,6 +184,26 @@ class Get:
             assert len(recommendations) == 1
 
         @clean_database
+        def when_special_character(self, app):
+            # given
+            user = create_user(email='test@email.com', password='P@55w0rd')
+            offerer = create_offerer()
+            venue = create_venue(offerer)
+            offer = create_event_offer(venue, event_name="Vortek's")
+            stock = create_stock_from_offer(offer)
+            PcObject.check_and_save(stock, user)
+
+            # when
+            response = TestClient().with_auth(user.email, user.clearTextPassword) \
+                .get(RECOMMENDATION_URL + '?keywords=vortek%27s')
+
+            # then
+            assert response.status_code == 200
+            recommendations = response.json()
+            assert recommendations[0]['offer']['eventOrThing']['name'] == "Vortek's"
+            assert len(recommendations) == 1
+
+        @clean_database
         def when_searching_by_keywords_with_non_matching_case(self, app):
             # given
             search = "keywords_string={}".format("rencontres")

--- a/tests/routes/recommendations_get_test.py
+++ b/tests/routes/recommendations_get_test.py
@@ -124,6 +124,25 @@ class Get:
             assert len(response.json()) == 0
 
         @clean_database
+        def when_keywords_contains_special_char(self, app):
+            # given
+            user = create_user(email='test@email.com', password='P@55w0rd')
+            offerer = create_offerer(validation_token='ABC123')
+            venue = create_venue(offerer)
+            offer = create_event_offer(venue, event_name='www.test.fr event')
+            recommendation = create_recommendation(offer, user)
+            stock = create_stock_from_offer(offer)
+            PcObject.check_and_save(stock, recommendation)
+
+            # when
+            response = TestClient().with_auth(user.email, user.clearTextPassword).get(
+                RECOMMENDATION_URL + '?keywords=https%3A%2F%2Fwww.test.fr%2F')
+
+            # then
+            assert response.status_code == 200
+            assert len(response.json()) == 0
+
+        @clean_database
         def when_searching_by_keywords_on_inactive_offerer(self, app):
             # given
             keywords_string = "Training"

--- a/tests/routes/recommendations_get_test.py
+++ b/tests/routes/recommendations_get_test.py
@@ -184,7 +184,7 @@ class Get:
             assert len(recommendations) == 1
 
         @clean_database
-        def when_special_character(self, app):
+        def when_keywords_contain_single_quote(self, app):
             # given
             user = create_user(email='test@email.com', password='P@55w0rd')
             offerer = create_offerer()

--- a/tests/utils_string_processing_test.py
+++ b/tests/utils_string_processing_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.string_processing import get_matched_string_index, get_price_value, tokenize_for_search
+from utils.string_processing import get_matched_string_index, get_price_value, remove_single_letters_for_search, tokenize_for_search
 
 
 @pytest.mark.standalone
@@ -26,3 +26,7 @@ def test_remove_special_character():
 @pytest.mark.standalone
 def test_tokenize_url():
     assert tokenize_for_search('http://www.t_est-toto.fr') == ['http', 'www', 't', 'est', 'toto', 'fr' ]
+
+@pytest.mark.standalone
+def test_tokenize_url():
+    assert remove_single_letters_for_search(['http', 'www', 't', 'est', 'toto', 'fr' ]) == ['http', 'www', 'est', 'toto', 'fr']

--- a/tests/utils_string_processing_test.py
+++ b/tests/utils_string_processing_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.string_processing import get_matched_string_index, get_price_value, parse_string
+from utils.string_processing import get_matched_string_index, get_price_value, tokenize_for_search
 
 
 @pytest.mark.standalone
@@ -15,11 +15,14 @@ def test_get_matched_string_index():
 def test_get_price_value():
     assert type(get_price_value('')) == int
 
-
 @pytest.mark.standalone
-def test_remove_http_from_url():
-    assert parse_string('http://www.test.fr') == 'www.test.fr'
+def test_remove_special_character():
+    assert tokenize_for_search("Læetitia a mangé's'") == ['læetitia', 'a', 'mangé', 's', '']
 
 @pytest.mark.standalone
 def test_remove_special_character():
-    assert parse_string("Vortek's") == 'Vortek'
+    assert tokenize_for_search("L'histoire sans fin") == ['l', 'histoire', 'sans', 'fin']
+
+@pytest.mark.standalone
+def test_tokenize_url():
+    assert tokenize_for_search('http://www.t_est-toto.fr') == ['http', 'www', 't', 'est', 'toto', 'fr' ]

--- a/tests/utils_string_processing_test.py
+++ b/tests/utils_string_processing_test.py
@@ -19,3 +19,7 @@ def test_get_price_value():
 @pytest.mark.standalone
 def test_remove_http_from_url():
     assert parse_string('http://www.test.fr') == 'www.test.fr'
+
+@pytest.mark.standalone
+def test_remove_special_character():
+    assert parse_string("Vortek's") == 'Vortek'

--- a/tests/utils_string_processing_test.py
+++ b/tests/utils_string_processing_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.string_processing import get_matched_string_index, get_price_value
+from utils.string_processing import get_matched_string_index, get_price_value, parse_string
 
 
 @pytest.mark.standalone
@@ -14,3 +14,8 @@ def test_get_matched_string_index():
 @pytest.mark.standalone
 def test_get_price_value():
     assert type(get_price_value('')) == int
+
+
+@pytest.mark.standalone
+def test_remove_http_from_url():
+    assert parse_string('http://www.test.fr') == 'www.test.fr'

--- a/utils/string_processing.py
+++ b/utils/string_processing.py
@@ -136,3 +136,6 @@ def get_camel_string(string):
 
 def tokenize_for_search(string):
     return re.split('[^0-9a-zÀ-ÿ]+', string.lower())
+
+def remove_single_letters_for_search(array_of_keywords):
+    return list(filter(lambda k: len(k) > 1, array_of_keywords))

--- a/utils/string_processing.py
+++ b/utils/string_processing.py
@@ -134,5 +134,7 @@ def get_price_value(price_string):
 def get_camel_string (string):
     return ''.join(word.capitalize() for word in string.split('_'))
 
-def parse_string(url):
-    return re.sub('http://|https://', '', url)
+def parse_string(text):
+    text_without_url = re.sub('http://|https://', '', text)
+    text_without_s =  re.sub("['s]+$", '', text_without_url)
+    return text_without_s

--- a/utils/string_processing.py
+++ b/utils/string_processing.py
@@ -133,3 +133,6 @@ def get_price_value(price_string):
 
 def get_camel_string (string):
     return ''.join(word.capitalize() for word in string.split('_'))
+
+def parse_string(url):
+    return re.sub('http://|https://', '', url)

--- a/utils/string_processing.py
+++ b/utils/string_processing.py
@@ -131,10 +131,8 @@ def get_price_value(price_string):
     else:
         return 0
 
-def get_camel_string (string):
+def get_camel_string(string):
     return ''.join(word.capitalize() for word in string.split('_'))
 
-def parse_string(text):
-    text_without_url = re.sub('http://|https://', '', text)
-    text_without_s =  re.sub("['s]+$", '', text_without_url)
-    return text_without_s
+def tokenize_for_search(string):
+    return re.split('[^0-9a-zÀ-ÿ]+', string.lower())


### PR DESCRIPTION
- j'ai corrigé l'erreur 500 avec un test à minima mais le regex pourrait être plus complet, je ne sais pas exactement quels caractères spéciaux font des erreurs 500 dans la requête sql  :
`to_tsvector_6': '::*', 'to_tsvector_7': 'french_unaccent', 'coalesce_12': '', 'param_5': ' ', 'coalesce_13': '', 'param_6': ' ', 'coalesce_14': '', 'to_tsvector_8': '::*', 'to_tsvector_9': '//www.test.fr/:*', 'to_tsvector_10': '//www.test.fr/:*', 'to_tsvector_11': '//www.test.fr/:*', 'to_tsvector_12': '//www.test.fr/:*', 'param_7': 10, 'param_8': 0}`

