### PR TITLE
(pC-1839) authorize to modify siret in patch venues route

### DIFF
--- a/routes/venues.py
+++ b/routes/venues.py
@@ -49,8 +49,8 @@ def create_venue():
 @login_required
 @expect_json_data
 def edit_venue(venueId):
-    check_valid_edition(request)
     venue = load_or_404(Venue, venueId)
+    check_valid_edition(request, venue)
     validate_coordinates(request.json.get('latitude', None), request.json.get('longitude', None))
     ensure_current_user_has_rights(RightsType.editor, venue.managingOffererId)
     venue.populateFromDict(request.json)

--- a/tests/routes/venues_test.py
+++ b/tests/routes/venues_test.py
@@ -35,27 +35,6 @@ class Patch:
 
     class Returns400:
         @clean_database
-        def when_trying_to_patch_siret(self, app):
-            # Given
-            offerer = create_offerer()
-            user = create_user()
-            user_offerer = create_user_offerer(user, offerer, is_admin=True)
-            siret = offerer.siren + '11111'
-            venue = create_venue(offerer, siret=siret)
-            PcObject.check_and_save(user_offerer, venue)
-            venue_data = {
-                'siret': offerer.siren + '12345',
-            }
-            auth_request = TestClient().with_auth(email=user.email)
-
-            # when
-            response = auth_request.patch(API_URL + '/venues/%s' % humanize(venue.id), json=venue_data)
-
-            # Then
-            assert response.status_code == 400
-            assert response.json()['siret'] == ['Vous ne pouvez pas modifier le siret d\'un lieu']
-
-        @clean_database
         def when_editing_is_virtual_and_managing_offerer_already_has_virtual_venue(self, app):
             # given
             offerer = create_offerer()

--- a/tests/validation_venues_test.py
+++ b/tests/validation_venues_test.py
@@ -4,7 +4,6 @@ from models import ApiErrors
 from validation.venues import validate_coordinates
 
 
-
 @pytest.mark.standalone
 def test_validate_coordinates_raises_an_api_errors_if_latitude_is_not_a_decimal():
     # when
@@ -85,4 +84,3 @@ def test_validate_coordinates_raises_an_api_errors_if_both_latitude_and_longitud
     # then
     assert e.value.errors['latitude'] == ['La latitude doit être comprise entre -90.0 et +90.0']
     assert e.value.errors['longitude'] == ['La longitude doit être comprise entre -180.0 et +180.0']
-

--- a/validation/venues.py
+++ b/validation/venues.py
@@ -19,11 +19,16 @@ def validate_coordinates(raw_latitude, raw_longitude):
         raise api_errors
 
 
-def check_valid_edition(request):
+def check_valid_edition(request, venue):
     managing_offerer_id = request.json.get('managingOffererId')
+    siret = request.json.get('siret')
     if managing_offerer_id:
         errors = ApiErrors()
         errors.addError('managingOffererId', 'Vous ne pouvez pas changer la structure d\'un lieu')
+        raise errors
+    if siret and venue.siret and siret != venue.siret:
+        errors = ApiErrors()
+        errors.addError('siret', 'Vous ne pouvez pas modifier le siret d\'un lieu')
         raise errors
 
 

--- a/validation/venues.py
+++ b/validation/venues.py
@@ -21,14 +21,9 @@ def validate_coordinates(raw_latitude, raw_longitude):
 
 def check_valid_edition(request):
     managing_offerer_id = request.json.get('managingOffererId')
-    siret = request.json.get('siret')
     if managing_offerer_id:
         errors = ApiErrors()
         errors.addError('managingOffererId', 'Vous ne pouvez pas changer la structure d\'un lieu')
-        raise errors
-    if siret:
-        errors = ApiErrors()
-        errors.addError('siret', 'Vous ne pouvez pas modifier le siret d\'un lieu')
         raise errors
 
 


### PR DESCRIPTION
Pour faire plus safe: on va empecher de remodifier un siret quand il existe deja.

Par contre quand il existe pas, c'est bon on peut l'ajouter.