### PR TITLE
Ajout du shebang

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 
 from flask import Flask


### PR DESCRIPTION
Là encore, je n'arrivais pas à lancer ce fichier dans Docker à cause de l'erreur suivante `OSError: [Errno 8] Exec format error`.
Il fallait donc ajouter le shebang en début de fichier pour que cela fonctionne.