### PR TITLE
(PC-1890) add new properties hasPhysicalVenues and hasOffers to user

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -158,6 +158,18 @@ class User(PcObject,
     def wallet_is_activated(self):
         return len(self.deposits) > 0
 
+    @property
+    def hasPhysicalVenues(self):
+        all_offerers = self.offerers
+        for offerer in all_offerers:
+            for venue in offerer.managedVenues:
+                if not venue.isVirtual:
+                    return True
+        return False
+
+    @property
+    def hasOffers(self):
+        return sum(map(lambda offerer: offerer.nOffers, self.offerers)) > 0
 
 class WalletBalance:
     CSV_HEADER = [

--- a/models/user.py
+++ b/models/user.py
@@ -160,16 +160,15 @@ class User(PcObject,
 
     @property
     def hasPhysicalVenues(self):
-        all_offerers = self.offerers
-        for offerer in all_offerers:
-            for venue in offerer.managedVenues:
-                if not venue.isVirtual:
-                    return True
+        for offerer in self.offerers:
+            if any([not venue.isVirtual for venue in offerer.managedVenues]):
+                return True
+
         return False
 
     @property
     def hasOffers(self):
-        return sum(map(lambda offerer: offerer.nOffers, self.offerers)) > 0
+        return any([offerer.nOffers > 0 for offerer in self.offerers])
 
 class WalletBalance:
     CSV_HEADER = [

--- a/sandboxes/scripts/utils/helpers.py
+++ b/sandboxes/scripts/utils/helpers.py
@@ -1,4 +1,4 @@
-from utils.includes import RECOMMENDATION_INCLUDES
+from utils.includes import RECOMMENDATION_INCLUDES, USER_INCLUDES
 
 def get_booking_helper(booking):
     return dict(booking.as_dict(), **{
@@ -64,7 +64,7 @@ def get_password_from_email(email):
     return minimal_password
 
 def get_user_helper(user):
-    return dict(user.as_dict(), **{
+    return dict(user.as_dict(include=USER_INCLUDES), **{
         "password": get_password_from_email(user.email)
     })
 

--- a/tests/models/users_test.py
+++ b/tests/models/users_test.py
@@ -227,12 +227,13 @@ class RealWalletBalanceTest:
         assert balance == Decimal(50)
 
 
-class hasPhysicalVenuesTest:
+class HasPhysicalVenuesTest:
     @clean_database
     def test_webapp_user_has_no_venue(self, app):
         # given
         user = create_user()
 
+        # when
         PcObject.save(user)
 
         # then
@@ -245,6 +246,8 @@ class hasPhysicalVenuesTest:
         offerer = create_offerer()
         user_offerer = create_user_offerer(user, offerer)
         offerer_venue = create_venue(offerer, is_virtual=True, siret=None)
+
+        # when
         PcObject.save(offerer_venue, user_offerer)
 
         # then

--- a/tests/routes/get_user_profile_test.py
+++ b/tests/routes/get_user_profile_test.py
@@ -3,9 +3,7 @@ from datetime import datetime, timedelta
 from models import PcObject, ThingType
 from tests.conftest import clean_database, TestClient
 
-from tests.test_utils import create_offer_with_thing_product, create_user, create_offerer, \
-    create_venue, \
-    create_stock_with_thing_offer, create_recommendation, create_deposit, create_booking
+from tests.test_utils import create_offer_with_thing_product, create_user, create_offerer, create_user_offerer, create_venue, create_stock_with_thing_offer, create_recommendation, create_deposit, create_booking
 
 class Get:
     class Returns200:
@@ -91,11 +89,11 @@ class Get:
             PcObject.save(offer, offer2, offerer2_virtual_venue, user_offerer, user_offerer2)
 
             # when
-            response = TestClient().with_auth('test@email.com').get(API_URL + '/users/current')
+            response = TestClient(app.test_client()).with_auth('test@email.com').get('/users/current')
 
             # Then
-            assert response.json()['hasPhysicalVenues'] is True
-            assert response.json()['hasOffers'] is True
+            assert response.json['hasPhysicalVenues'] is True
+            assert response.json['hasOffers'] is True
 
     class Returns400:
         @clean_database

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -202,6 +202,8 @@ USER_INCLUDES = [
     '-resetPasswordToken',
     '-resetPasswordTokenValidityLimit',
     '-validationToken',
+    'hasPhysicalVenues',
+    'hasOffers',
     'wallet_balance',
     'wallet_is_activated'
 ]


### PR DESCRIPTION
Création de deux nouvelles propriétés permettant de rediriger les utilisateurs vers offres ou structures suivant s'ils ont déjà créé un lieu physique ou pas. Et de leur afficher des messages sur le pro en fonction de ces valeurs (hey créé un lieu !)

Par défaut, ils ont tous un lieu virtuel dans lequel ils peuvent créer une offre numérique.
