### PR TITLE
(PC-2049) Remove call to check_feature_consistency since at this poin…

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,7 +76,6 @@ with app.app_context():
         install_features()
     import utils.login_manager
     install_routes()
-    check_feature_consistency()
     install_admin_views(admin, db.session)
 
     app.mailjet_client = Client(auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3')


### PR DESCRIPTION
…t the feature table does not exist in dev, integration and prod env and alembic revisions are ran after app.py is ran => the app is crashing at startup. This function call will be added again in future versions.