### PR TITLE
(pC-2139) [A MERGER EN MEME TEMP QUE PR WEBAPP] adapted expenses and booking includes

### DIFF
--- a/domain/expenses.py
+++ b/domain/expenses.py
@@ -1,10 +1,23 @@
 from decimal import Decimal
 from typing import List, Union
 
-from models import ThingType, Booking, Product
+from models.booking import Booking
+from models.product import Product
+from models.offer_type import ThingType
 
-PHYSICAL_EXPENSES_CAPPED_TYPES = [ThingType.AUDIOVISUEL, ThingType.INSTRUMENT, ThingType.JEUX, ThingType.LIVRE_EDITION, ThingType.MUSIQUE]
-DIGITAL_EXPENSES_CAPPED_TYPES = [ThingType.AUDIOVISUEL, ThingType.JEUX_VIDEO, ThingType.MUSIQUE, ThingType.PRESSE_ABO]
+PHYSICAL_EXPENSES_CAPPED_TYPES = [
+    ThingType.AUDIOVISUEL,
+    ThingType.INSTRUMENT,
+    ThingType.JEUX,
+    ThingType.LIVRE_EDITION,
+    ThingType.MUSIQUE
+]
+DIGITAL_EXPENSES_CAPPED_TYPES = [
+    ThingType.AUDIOVISUEL,
+    ThingType.JEUX_VIDEO,
+    ThingType.MUSIQUE,
+    ThingType.PRESSE_ABO
+]
 
 SUBVENTION_TOTAL = Decimal(500)
 SUBVENTION_PHYSICAL_THINGS = Decimal(200)

--- a/domain/favorites.py
+++ b/domain/favorites.py
@@ -1,4 +1,5 @@
-from models import Favorite, Mediation, Offer, User
+from typing import List
+from models import Booking, Favorite, Mediation, Offer, User
 
 
 def create_favorite(mediation: Mediation, offer: Offer, user: User) -> Favorite:
@@ -7,3 +8,9 @@ def create_favorite(mediation: Mediation, offer: Offer, user: User) -> Favorite:
     favorite.offer = offer
     favorite.user = user
     return favorite
+
+def find_first_matching_booking_from_favorite(favorite: Favorite, user: User) -> Booking:
+    for stock in favorite.offer.stocks:
+         for booking in stock.bookings:
+            if booking.userId == user.id:
+                return booking

--- a/models/booking.py
+++ b/models/booking.py
@@ -152,6 +152,14 @@ class Booking(PcObject, Model, VersionedMixin):
             self.statusLabel
         ]
 
+    @property
+    def thumbUrl(self):
+        if self.recommendation:
+            return self.recommendation.thumbUrl
+
+        if self.stock.offer.product.thumbCount:
+            return self.stock.offer.product.thumbUrl
+
 class ActivationUser:
     CSV_HEADER = [
         'Prénom',

--- a/models/favorite.py
+++ b/models/favorite.py
@@ -31,3 +31,11 @@ class Favorite(PcObject, Model):
     mediation = relationship('Mediation',
                              foreign_keys=[mediationId],
                              backref='favorites')
+
+    @property
+    def thumbUrl(self):
+        if self.mediationId:
+            return self.mediation.thumbUrl
+
+        if self.offer.product.thumbCount:
+            return self.offer.product.thumbUrl

--- a/models/recommendation.py
+++ b/models/recommendation.py
@@ -95,3 +95,10 @@ class Recommendation(PcObject, Model):
 
         if self.offer.product.thumbCount:
             return self.offer.product.thumbUrl
+
+    @property
+    def discoveryIdentifier(self):
+        if self.offer and self.offer.productId:
+            return 'product_{}'.format(self.offer.productId)
+        if self.mediation and self.mediation.tutoIndex != None:
+            return 'tuto_{}'.format(self.mediation.tutoIndex)

--- a/models/user.py
+++ b/models/user.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
+from domain.expenses import get_expenses
 from models.versioned_mixin import VersionedMixin
 from models.db import Model, db
 from models.needs_validation_mixin import NeedsValidationMixin
@@ -143,6 +144,10 @@ class User(PcObject,
         self.password = bcrypt.hashpw(newpass.encode('utf-8'), bcrypt.gensalt())
         self.resetPasswordToken = None
         self.resetPasswordTokenValidityLimit = None
+
+    @property
+    def expenses(self):
+        return get_expenses(self.userBookings)
 
     @property
     def real_wallet_balance(self):

--- a/routes/bookings.py
+++ b/routes/bookings.py
@@ -19,7 +19,8 @@ from repository.booking_queries import find_active_bookings_by_user_id, \
     find_all_offerer_bookings, find_all_digital_bookings_for_offerer
 from repository.user_offerer_queries import filter_query_where_user_is_user_offerer_and_is_validated
 from utils.human_ids import dehumanize, humanize
-from utils.includes import BOOKING_INCLUDES, BOOKING_WITH_USER_INCLUDES
+from utils.includes import WEBAPP_GET_BOOKING_INCLUDES, \
+                           WEBAPP_PATCH_POST_BOOKING_INCLUDES
 from utils.mailing import MailServiceException, send_raw_email
 from utils.rest import ensure_current_user_has_rights, \
     expect_json_data
@@ -99,7 +100,7 @@ def get_bookings_csv():
 @login_required
 def get_bookings():
     bookings = Booking.query.filter_by(userId=current_user.id).all()
-    return jsonify([booking.as_dict(include=BOOKING_INCLUDES)
+    return jsonify([booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)
                     for booking in bookings]), 200
 
 
@@ -107,7 +108,7 @@ def get_bookings():
 @login_required
 def get_booking(booking_id):
     booking = Booking.query.filter_by(id=dehumanize(booking_id)).first_or_404()
-    return jsonify(booking.as_dict(include=BOOKING_INCLUDES)), 200
+    return jsonify(booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)), 200
 
 
 @app.route('/bookings', methods=['POST'])
@@ -160,7 +161,11 @@ def create_booking():
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(new_booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 201
+    new_booking_dict = new_booking.as_dict(
+        include=WEBAPP_PATCH_POST_BOOKING_INCLUDES
+    )
+
+    return jsonify(new_booking_dict), 201
 
 
 @app.route('/bookings/<booking_id>', methods=['PATCH'])
@@ -195,7 +200,11 @@ def patch_booking(booking_id):
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 200
+    booking_dict = booking.as_dict(
+        include=WEBAPP_PATCH_POST_BOOKING_INCLUDES
+    )
+
+    return jsonify(booking_dict), 200
 
 
 @app.route('/bookings/token/<token>', methods=["GET"])

--- a/routes/bookings.py
+++ b/routes/bookings.py
@@ -1,5 +1,3 @@
-""" bookings routes """
-
 from itertools import chain
 
 import dateutil
@@ -21,7 +19,7 @@ from repository.booking_queries import find_active_bookings_by_user_id, \
     find_all_offerer_bookings, find_all_digital_bookings_for_offerer
 from repository.user_offerer_queries import filter_query_where_user_is_user_offerer_and_is_validated
 from utils.human_ids import dehumanize, humanize
-from utils.includes import BOOKING_INCLUDES
+from utils.includes import BOOKING_INCLUDES, BOOKING_WITH_USER_INCLUDES
 from utils.mailing import MailServiceException, send_raw_email
 from utils.rest import ensure_current_user_has_rights, \
     expect_json_data
@@ -162,7 +160,7 @@ def create_booking():
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(new_booking.as_dict(include=BOOKING_INCLUDES)), 201
+    return jsonify(new_booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 201
 
 
 @app.route('/bookings/<booking_id>', methods=['PATCH'])
@@ -197,7 +195,7 @@ def patch_booking(booking_id):
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(booking.as_dict(include=BOOKING_INCLUDES)), 200
+    return jsonify(booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 200
 
 
 @app.route('/bookings/token/<token>', methods=["GET"])

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -14,7 +14,7 @@ from repository.booking_queries import find_bookings_from_recommendation
 from repository.recommendation_queries import update_read_recommendations
 from utils.config import BLOB_SIZE
 from utils.human_ids import dehumanize
-from utils.includes import BOOKING_INCLUDES, RECOMMENDATION_INCLUDES
+from utils.includes import WEBAPP_GET_BOOKING_INCLUDES, RECOMMENDATION_INCLUDES
 from utils.logger import logger
 from utils.rest import expect_json_data
 
@@ -147,4 +147,4 @@ def _serialize_bookings(bookings):
 
 
 def _serialize_booking(booking):
-    return booking.as_dict(include=BOOKING_INCLUDES)
+    return booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)

--- a/routes/users.py
+++ b/routes/users.py
@@ -3,7 +3,6 @@
 from flask import current_app as app, jsonify, request
 from flask_login import current_user, login_required, logout_user, login_user
 
-from domain.expenses import get_expenses
 from models import PcObject
 from repository.user_queries import find_user_by_reset_password_token
 from utils.credentials import get_user_with_credentials
@@ -17,9 +16,8 @@ from validation.users import check_allowed_changes_for_user, check_valid_signin
 @app.route("/users/current", methods=["GET"])
 @login_required
 def get_profile():
-    user = current_user.as_dict(include=USER_INCLUDES)
-    user['expenses'] = get_expenses(current_user.userBookings)
-    return jsonify(user)
+    user_dict = current_user.as_dict(include=USER_INCLUDES)
+    return jsonify(user_dict)
 
 
 @app.route("/users/token/<token>", methods=["GET"])
@@ -41,7 +39,6 @@ def patch_profile():
     current_user.populate_from_dict(request.json)
     PcObject.save(current_user)
     user = current_user.as_dict(include=USER_INCLUDES)
-    user['expenses'] = get_expenses(current_user.userBookings)
     return jsonify(user), 200
 
 
@@ -55,7 +52,6 @@ def signin():
     login_user(user, remember=True)
     stamp_session(user)
     user_dict = user.as_dict(include=USER_INCLUDES)
-    user_dict['expenses'] = get_expenses(user.userBookings)
     return jsonify(user_dict), 200
 
 

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -152,7 +152,11 @@ FAVORITE_INCLUDES = [
 ]
 
 RECOMMENDATION_INCLUDES = [
-    "mediation",
+    "discoveryIdentifier",
+    {
+        "key": "mediation",
+        "sub_joins": ["thumbUrl"]
+    },
     {
         "key": "offer",
         "sub_joins": [
@@ -162,7 +166,6 @@ RECOMMENDATION_INCLUDES = [
             "dateRange",
             "isEvent",
             "isThing",
-            "mediation",
             "stocks",
             {
                 "key": "venue",
@@ -202,16 +205,23 @@ WEBAPP_GET_BOOKING_INCLUDES = [
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
-                    "product",
+                    {
+                        "key": "product",
+                        "sub_joins": ["thumbUrl"]
+                    },
                     "stocks",
                     "venue",
                 ]
             },
-            "mediation",
+            {
+                "key": "mediation",
+                "sub_joins": ["thumbUrl"]
+            },
             "thumbUrl"
         ]
     },
-    "stock"
+    "stock",
+    "thumbUrl"
 ]
 
 WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
@@ -235,11 +245,15 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
                     "venue",
                 ]
             },
-            "mediation",
+            {
+                "key": "mediation",
+                "sub_joins": ["thumbUrl"]
+            },
             "thumbUrl"
         ]
     },
     "stock",
+    "thumbUrl",
     {
         "key": "user",
         "sub_joins": USER_INCLUDES

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -215,6 +215,7 @@ WEBAPP_GET_BOOKING_INCLUDES = [
                     "isFinished",
                     "isFullyBooked",
                     "product",
+                    "stocks",
                     "venue",
                 ]
             },

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -123,43 +123,32 @@ OFFER_INCLUDES = [
 
 FAVORITE_INCLUDES = [
     "-userId",
-    "mediation",
     {
-        "key": "offer",
-        "sub_joins": [
-            'favorites',
-            'isFinished',
-            'isFullyBooked',
-            "dateRange",
-            "isEvent",
-            "isThing",
-            "mediation",
-            "stocks",
-            {
-                "key": "venue",
-                "sub_joins": ["managingOfferer"]
-            },
-            {
-                "key": "stocks",
-                "sub_joins": ['bookings']
-            },
-            {
-                "key": "product",
-                "sub_joins": ["thumbUrl", "offerType"]
-            }
-        ]
-    },
-    {
-        "key": "recommendation",
+        "key": "mediation",
         "sub_joins": [
             "thumbUrl"
         ]
     },
     {
-        "key": "mediation",
-        "sub_joins": ["thumbUrl"]
+        "key": "offer",
+        "sub_joins": [
+            "dateRange",
+            "favorites",
+            "isEvent",
+            "isFinished",
+            "isThing",
+            "isFullyBooked",
+            {
+                "key": "product",
+                "sub_joins": [
+                    "thumbUrl"
+                ]
+            },
+            "stocks",
+            "venue",
+        ]
     },
-    "isFavorite"
+    "thumbUrl"
 ]
 
 RECOMMENDATION_INCLUDES = [
@@ -185,8 +174,7 @@ RECOMMENDATION_INCLUDES = [
             }
         ]
     },
-    "thumbUrl",
-    "isFavorite"
+    "thumbUrl"
 ]
 
 USER_INCLUDES = [

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -202,7 +202,7 @@ USER_INCLUDES = [
     'wallet_is_activated'
 ]
 
-BOOKING_INCLUDES = [
+WEBAPP_GET_BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
     {
@@ -225,7 +225,28 @@ BOOKING_INCLUDES = [
     "stock"
 ]
 
-BOOKING_WITH_USER_INCLUDES = BOOKING_INCLUDES + [
+WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
+    "completedUrl",
+    "isUserCancellable",
+    {
+        "key": "recommendation",
+        "sub_joins": [
+            {
+                "key": "offer",
+                "sub_joins": [
+                    "favorites",
+                    "isFinished",
+                    "isFullyBooked",
+                    "product",
+                    "stocks",
+                    "venue",
+                ]
+            },
+            "mediation",
+            "thumbUrl"
+        ]
+    },
+    "stock",
     {
         "key": "user",
         "sub_joins": USER_INCLUDES

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -234,10 +234,14 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
             {
                 "key": "offer",
                 "sub_joins": [
+                    "dateRange",
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
-                    "product",
+                    {
+                        "key": "product",
+                        "sub_joins": ["offerType", "thumbUrl"]
+                    },
                     "stocks",
                     "venue",
                 ]

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -125,9 +125,7 @@ FAVORITE_INCLUDES = [
     "-userId",
     {
         "key": "mediation",
-        "sub_joins": [
-            "thumbUrl"
-        ]
+        "sub_joins": ["thumbUrl"]
     },
     {
         "key": "offer",
@@ -140,9 +138,7 @@ FAVORITE_INCLUDES = [
             "isFullyBooked",
             {
                 "key": "product",
-                "sub_joins": [
-                    "thumbUrl"
-                ]
+                "sub_joins": ["thumbUrl", "offerType"]
             },
             "stocks",
             "venue",

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -189,6 +189,19 @@ RECOMMENDATION_INCLUDES = [
     "isFavorite"
 ]
 
+USER_INCLUDES = [
+    '-culturalSurveyId',
+    '-password',
+    '-resetPasswordToken',
+    '-resetPasswordTokenValidityLimit',
+    '-validationToken',
+    'expenses',
+    'hasPhysicalVenues',
+    'hasOffers',
+    'wallet_balance',
+    'wallet_is_activated'
+]
+
 BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
@@ -210,6 +223,13 @@ BOOKING_INCLUDES = [
         ]
     },
     "stock"
+]
+
+BOOKING_WITH_USER_INCLUDES = BOOKING_INCLUDES + [
+    {
+        "key": "user",
+        "sub_joins": USER_INCLUDES
+    }
 ]
 
 PRO_BOOKING_INCLUDES = [
@@ -238,18 +258,6 @@ PRO_BOOKING_INCLUDES = [
             'lastName': element['lastName']
         }),
     }
-]
-
-USER_INCLUDES = [
-    '-culturalSurveyId',
-    '-password',
-    '-resetPasswordToken',
-    '-resetPasswordTokenValidityLimit',
-    '-validationToken',
-    'hasPhysicalVenues',
-    'hasOffers',
-    'wallet_balance',
-    'wallet_is_activated'
 ]
 
 VENUE_INCLUDES = [

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -1,5 +1,3 @@
-""" includes """
-
 OFFERER_INCLUDES = [
     {
         "key": "managedVenues",
@@ -195,21 +193,6 @@ BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
     {
-        "key": "stock",
-        "sub_joins":
-            [
-                {
-                    "key": "resolvedOffer",
-                    "sub_joins": [
-                        "product",
-                        "venue",
-                        'isFinished',
-                        'isFullyBooked'
-                    ]
-                }
-            ]
-    },
-    {
         "key": "recommendation",
         "sub_joins": [
             {
@@ -226,6 +209,7 @@ BOOKING_INCLUDES = [
             "thumbUrl"
         ]
     },
+    "stock"
 ]
 
 PRO_BOOKING_INCLUDES = [


### PR DESCRIPTION
La pr correspondante sur webapp a besoin de deux choses:

- mettre la propriété 'expenses' comme property dans le model user pour etre plus consistent avec le reste du code

- faire en sorte que les POST et PATCH /bookings renvoie en meme temps l'objet user, pour pouvoir directement rafraichir le wallet_balance cote front ; et cela sans demander de faire une deuxieme requete get uses/current.

- faire en sorte aussi les POST et PATCH /bookings renvoie d'avantage d'informations sur l'objet recommendation : { offer { offerType } } associé au booking, car sinon cette information est overridée et disparaît au succes de ces requetes, faisant bugger l'action de reserver un booking quand on est sur la page recherche. 
