### PR TITLE
(pC-2139) [A MERGER EN MEME TEMPS QUE CELLE SUR WEBAPP] recto verso booking share for all pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs: # a collection of steps
             . venv/bin/activate
             python -m nltk.downloader punkt stopwords
             pytest tests --cov --cov-report html -x
-            coveralls
       - store_artifacts:
           path: htmlcov
 

--- a/domain/expenses.py
+++ b/domain/expenses.py
@@ -1,10 +1,23 @@
 from decimal import Decimal
 from typing import List, Union
 
-from models import ThingType, Booking, Product
+from models.booking import Booking
+from models.product import Product
+from models.offer_type import ThingType
 
-PHYSICAL_EXPENSES_CAPPED_TYPES = [ThingType.AUDIOVISUEL, ThingType.INSTRUMENT, ThingType.JEUX, ThingType.LIVRE_EDITION, ThingType.MUSIQUE]
-DIGITAL_EXPENSES_CAPPED_TYPES = [ThingType.AUDIOVISUEL, ThingType.JEUX_VIDEO, ThingType.MUSIQUE, ThingType.PRESSE_ABO]
+PHYSICAL_EXPENSES_CAPPED_TYPES = [
+    ThingType.AUDIOVISUEL,
+    ThingType.INSTRUMENT,
+    ThingType.JEUX,
+    ThingType.LIVRE_EDITION,
+    ThingType.MUSIQUE
+]
+DIGITAL_EXPENSES_CAPPED_TYPES = [
+    ThingType.AUDIOVISUEL,
+    ThingType.JEUX_VIDEO,
+    ThingType.MUSIQUE,
+    ThingType.PRESSE_ABO
+]
 
 SUBVENTION_TOTAL = Decimal(500)
 SUBVENTION_PHYSICAL_THINGS = Decimal(200)

--- a/domain/favorites.py
+++ b/domain/favorites.py
@@ -1,4 +1,5 @@
-from models import Favorite, Mediation, Offer, User
+from typing import List
+from models import Booking, Favorite, Mediation, Offer, User
 
 
 def create_favorite(mediation: Mediation, offer: Offer, user: User) -> Favorite:
@@ -7,3 +8,9 @@ def create_favorite(mediation: Mediation, offer: Offer, user: User) -> Favorite:
     favorite.offer = offer
     favorite.user = user
     return favorite
+
+def find_first_matching_booking_from_favorite(favorite: Favorite, user: User) -> Booking:
+    for stock in favorite.offer.stocks:
+         for booking in stock.bookings:
+            if booking.userId == user.id:
+                return booking

--- a/models/booking.py
+++ b/models/booking.py
@@ -152,6 +152,14 @@ class Booking(PcObject, Model, VersionedMixin):
             self.statusLabel
         ]
 
+    @property
+    def thumbUrl(self):
+        if self.recommendation:
+            return self.recommendation.thumbUrl
+
+        if self.stock.offer.product.thumbCount:
+            return self.stock.offer.product.thumbUrl
+
 class ActivationUser:
     CSV_HEADER = [
         'Prénom',

--- a/models/favorite.py
+++ b/models/favorite.py
@@ -31,3 +31,11 @@ class Favorite(PcObject, Model):
     mediation = relationship('Mediation',
                              foreign_keys=[mediationId],
                              backref='favorites')
+
+    @property
+    def thumbUrl(self):
+        if self.mediationId:
+            return self.mediation.thumbUrl
+
+        if self.offer.product.thumbCount:
+            return self.offer.product.thumbUrl

--- a/models/recommendation.py
+++ b/models/recommendation.py
@@ -95,3 +95,10 @@ class Recommendation(PcObject, Model):
 
         if self.offer.product.thumbCount:
             return self.offer.product.thumbUrl
+
+    @property
+    def discoveryIdentifier(self):
+        if self.offer and self.offer.productId:
+            return 'product_{}'.format(self.offer.productId)
+        if self.mediation and self.mediation.tutoIndex != None:
+            return 'tuto_{}'.format(self.mediation.tutoIndex)

--- a/models/user.py
+++ b/models/user.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
 
+from domain.expenses import get_expenses
 from models.versioned_mixin import VersionedMixin
 from models.db import Model, db
 from models.needs_validation_mixin import NeedsValidationMixin
@@ -143,6 +144,10 @@ class User(PcObject,
         self.password = bcrypt.hashpw(newpass.encode('utf-8'), bcrypt.gensalt())
         self.resetPasswordToken = None
         self.resetPasswordTokenValidityLimit = None
+
+    @property
+    def expenses(self):
+        return get_expenses(self.userBookings)
 
     @property
     def real_wallet_balance(self):

--- a/routes/bookings.py
+++ b/routes/bookings.py
@@ -19,7 +19,8 @@ from repository.booking_queries import find_active_bookings_by_user_id, \
     find_all_offerer_bookings, find_all_digital_bookings_for_offerer
 from repository.user_offerer_queries import filter_query_where_user_is_user_offerer_and_is_validated
 from utils.human_ids import dehumanize, humanize
-from utils.includes import BOOKING_INCLUDES, BOOKING_WITH_USER_INCLUDES
+from utils.includes import WEBAPP_GET_BOOKING_INCLUDES, \
+                           WEBAPP_PATCH_POST_BOOKING_INCLUDES
 from utils.mailing import MailServiceException, send_raw_email
 from utils.rest import ensure_current_user_has_rights, \
     expect_json_data
@@ -99,7 +100,7 @@ def get_bookings_csv():
 @login_required
 def get_bookings():
     bookings = Booking.query.filter_by(userId=current_user.id).all()
-    return jsonify([booking.as_dict(include=BOOKING_INCLUDES)
+    return jsonify([booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)
                     for booking in bookings]), 200
 
 
@@ -107,7 +108,7 @@ def get_bookings():
 @login_required
 def get_booking(booking_id):
     booking = Booking.query.filter_by(id=dehumanize(booking_id)).first_or_404()
-    return jsonify(booking.as_dict(include=BOOKING_INCLUDES)), 200
+    return jsonify(booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)), 200
 
 
 @app.route('/bookings', methods=['POST'])
@@ -160,7 +161,11 @@ def create_booking():
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(new_booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 201
+    new_booking_dict = new_booking.as_dict(
+        include=WEBAPP_PATCH_POST_BOOKING_INCLUDES
+    )
+
+    return jsonify(new_booking_dict), 201
 
 
 @app.route('/bookings/<booking_id>', methods=['PATCH'])
@@ -195,7 +200,11 @@ def patch_booking(booking_id):
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 200
+    booking_dict = booking.as_dict(
+        include=WEBAPP_PATCH_POST_BOOKING_INCLUDES
+    )
+
+    return jsonify(booking_dict), 200
 
 
 @app.route('/bookings/token/<token>', methods=["GET"])

--- a/routes/bookings.py
+++ b/routes/bookings.py
@@ -1,5 +1,3 @@
-""" bookings routes """
-
 from itertools import chain
 
 import dateutil
@@ -21,7 +19,7 @@ from repository.booking_queries import find_active_bookings_by_user_id, \
     find_all_offerer_bookings, find_all_digital_bookings_for_offerer
 from repository.user_offerer_queries import filter_query_where_user_is_user_offerer_and_is_validated
 from utils.human_ids import dehumanize, humanize
-from utils.includes import BOOKING_INCLUDES
+from utils.includes import BOOKING_INCLUDES, BOOKING_WITH_USER_INCLUDES
 from utils.mailing import MailServiceException, send_raw_email
 from utils.rest import ensure_current_user_has_rights, \
     expect_json_data
@@ -162,7 +160,7 @@ def create_booking():
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(new_booking.as_dict(include=BOOKING_INCLUDES)), 201
+    return jsonify(new_booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 201
 
 
 @app.route('/bookings/<booking_id>', methods=['PATCH'])
@@ -197,7 +195,7 @@ def patch_booking(booking_id):
     except MailServiceException as e:
         app.logger.error('Mail service failure', e)
 
-    return jsonify(booking.as_dict(include=BOOKING_INCLUDES)), 200
+    return jsonify(booking.as_dict(include=BOOKING_WITH_USER_INCLUDES)), 200
 
 
 @app.route('/bookings/token/<token>', methods=["GET"])

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -34,11 +34,11 @@ def add_to_favorite():
 
     return jsonify(_serialize_favorite(favorite)), 201
 
-
+@app.route('/favorites/<offer_id>', methods=['DELETE'])
 @app.route('/favorites/<offer_id>/<mediation_id>', methods=['DELETE'])
 @feature_required(FeatureToggle.FAVORITE_OFFER)
 @login_required
-def delete_favorite(offer_id, mediation_id):
+def delete_favorite(offer_id, mediation_id=None):
     dehumanized_offer_id = dehumanize(offer_id)
     dehumanized_mediation_id = dehumanize(mediation_id)
 
@@ -46,10 +46,11 @@ def delete_favorite(offer_id, mediation_id):
                                                           dehumanized_offer_id,
                                                           current_user.id) \
         .first_or_404()
+    favorite_id = favorite.id
 
     PcObject.delete(favorite)
 
-    return jsonify(favorite.as_dict()), 200
+    return jsonify({ "id": favorite_id }), 200
 
 
 @app.route('/favorites', methods=['GET'])

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -50,7 +50,7 @@ def delete_favorite(offer_id, mediation_id=None):
 
     PcObject.delete(favorite)
 
-    return jsonify({ "id": favorite_id }), 200
+    return jsonify(favorite.as_dict()), 200
 
 
 @app.route('/favorites', methods=['GET'])

--- a/routes/favorites.py
+++ b/routes/favorites.py
@@ -10,7 +10,7 @@ from flask_login import current_user, login_required
 
 from domain.favorites import find_first_matching_booking_from_favorite
 from repository.booking_queries import find_bookings_from_recommendation
-from validation.offers import check_offer_id_and_mediation_id_are_present_in_request
+from validation.offers import check_offer_id_is_present_in_request
 from utils.human_ids import dehumanize
 from utils.includes import FAVORITE_INCLUDES, \
                            RECOMMENDATION_INCLUDES, \
@@ -22,12 +22,14 @@ from utils.rest import load_or_404
 @feature_required(FeatureToggle.FAVORITE_OFFER)
 @login_required
 def add_to_favorite():
+    mediation = None
     offer_id = request.json.get('offerId')
     mediation_id = request.json.get('mediationId')
-    check_offer_id_and_mediation_id_are_present_in_request(offer_id, mediation_id)
+    check_offer_id_is_present_in_request(offer_id)
 
     offer = load_or_404(Offer, offer_id)
-    mediation = load_or_404(Mediation, mediation_id)
+    if mediation_id != None:
+        mediation = load_or_404(Mediation, mediation_id)
 
     favorite = create_favorite(mediation, offer, current_user)
     PcObject.save(favorite)

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -14,7 +14,7 @@ from repository.booking_queries import find_bookings_from_recommendation
 from repository.recommendation_queries import update_read_recommendations
 from utils.config import BLOB_SIZE
 from utils.human_ids import dehumanize
-from utils.includes import BOOKING_INCLUDES, RECOMMENDATION_INCLUDES
+from utils.includes import WEBAPP_GET_BOOKING_INCLUDES, RECOMMENDATION_INCLUDES
 from utils.logger import logger
 from utils.rest import expect_json_data
 
@@ -147,4 +147,4 @@ def _serialize_bookings(bookings):
 
 
 def _serialize_booking(booking):
-    return booking.as_dict(include=BOOKING_INCLUDES)
+    return booking.as_dict(include=WEBAPP_GET_BOOKING_INCLUDES)

--- a/routes/users.py
+++ b/routes/users.py
@@ -3,7 +3,6 @@
 from flask import current_app as app, jsonify, request
 from flask_login import current_user, login_required, logout_user, login_user
 
-from domain.expenses import get_expenses
 from models import PcObject
 from repository.user_queries import find_user_by_reset_password_token
 from utils.credentials import get_user_with_credentials
@@ -17,9 +16,8 @@ from validation.users import check_allowed_changes_for_user, check_valid_signin
 @app.route("/users/current", methods=["GET"])
 @login_required
 def get_profile():
-    user = current_user.as_dict(include=USER_INCLUDES)
-    user['expenses'] = get_expenses(current_user.userBookings)
-    return jsonify(user)
+    user_dict = current_user.as_dict(include=USER_INCLUDES)
+    return jsonify(user_dict)
 
 
 @app.route("/users/token/<token>", methods=["GET"])
@@ -41,7 +39,6 @@ def patch_profile():
     current_user.populate_from_dict(request.json)
     PcObject.save(current_user)
     user = current_user.as_dict(include=USER_INCLUDES)
-    user['expenses'] = get_expenses(current_user.userBookings)
     return jsonify(user), 200
 
 
@@ -55,7 +52,6 @@ def signin():
     login_user(user, remember=True)
     stamp_session(user)
     user_dict = user.as_dict(include=USER_INCLUDES)
-    user_dict['expenses'] = get_expenses(user.userBookings)
     return jsonify(user_dict), 200
 
 

--- a/tests/models/recommendation_test.py
+++ b/tests/models/recommendation_test.py
@@ -92,3 +92,22 @@ def test_model_should_return_true_if_favorite_exists_for_offer_mediation_and_use
 
     # then
     assert recommendation.isFavorite is True
+
+
+@clean_database
+def test_model_should_return_true_if_favorite_exists_for_offer_without_mediation_and_user(app):
+    # given
+    user = create_user(email='user@test.com')
+    offerer = create_offerer()
+    venue = create_venue(offerer)
+    offer = create_offer_with_event_product(venue)
+    mediation = None
+    favorite = create_favorite(mediation, offer, user)
+    PcObject.save(favorite)
+
+    # when
+    recommendation = create_recommendation(offer, user, mediation=mediation)
+    PcObject.save(recommendation)
+
+    # then
+    assert recommendation.isFavorite is True

--- a/tests/routes/delete_favorites_test.py
+++ b/tests/routes/delete_favorites_test.py
@@ -8,8 +8,8 @@ from utils.human_ids import humanize
 class Delete:
     class Returns204:
         @clean_database
-        def when_favorite_exists(self, app):
-            # given
+        def when_favorite_exists_with_offerId_and_mediationId(self, app):
+            # Given
             user = create_user(email='test@email.com')
             offerer = create_offerer()
             venue = create_venue(offerer, postal_code='29100', siret='12345678912341')
@@ -29,10 +29,35 @@ class Delete:
             deleted_favorite = Favorite.query.first()
             assert deleted_favorite is None
 
+
+        @clean_database
+        def when_favorite_exists_with_offerId_only(self, app):
+            # Given
+            user = create_user(email='test@email.com')
+            offerer = create_offerer()
+            venue = create_venue(
+                offerer, postal_code='29100', siret='12345678912341')
+            offer = create_offer_with_thing_product(venue, thumb_count=0)
+            mediation = None
+            recommendation = create_recommendation(
+                offer=offer, user=user, mediation=mediation)
+            favorite = create_favorite(mediation, offer, user)
+            PcObject.save(recommendation, user, favorite)
+
+            # When
+            response = TestClient(app.test_client()).with_auth(user.email).delete(
+                f'{API_URL}/favorites/{humanize(offer.id)}')
+
+            # Then
+            assert response.status_code == 200
+            assert 'id' in response.json
+            deleted_favorite = Favorite.query.first()
+            assert deleted_favorite is None
+
     class Returns404:
         @clean_database
         def when_expected_parameters_are_not_given(self, app):
-            # given
+            # Given
             user = create_user(email='test@email.com')
             offerer = create_offerer()
             venue = create_venue(offerer, postal_code='29100', siret='12345678912341')
@@ -51,7 +76,7 @@ class Delete:
 
         @clean_database
         def when_favorite_does_not_exist(self, app):
-            # given
+            # Given
             user = create_user(email='test@email.com')
             offerer = create_offerer()
             venue = create_venue(offerer, postal_code='29100', siret='12345678912341')

--- a/tests/routes/post_favorites_test.py
+++ b/tests/routes/post_favorites_test.py
@@ -24,26 +24,7 @@ class Post:
 
             # Then
             assert response.status_code == 400
-            assert response.json['global'] == ["Les paramères offerId et mediationId sont obligatoires"]
-
-        @clean_database
-        def when_mediation_id_is_not_received(self, app):
-            # Given
-            user = create_user(email='test@email.com')
-            PcObject.save(user)
-
-            json = {
-                'offerId': 'BA',
-            }
-
-            # When
-            response = TestClient(app.test_client()).with_auth(user.email).post(
-                f'{API_URL}/favorites',
-                json=json)
-
-            # Then
-            assert response.status_code == 400
-            assert response.json['global'] == ["Les paramères offerId et mediationId sont obligatoires"]
+            assert response.json['global'] == ["Le paramètre offerId est obligatoire"]
 
     class Returns404:
         @clean_database
@@ -94,7 +75,6 @@ class Post:
             # Then
             assert response.status_code == 404
 
-
     class Returns201:
         @clean_database
         def when_offer_is_added_as_favorite_for_current_user(self, app):
@@ -124,3 +104,25 @@ class Post:
             assert favorite.offerId == offer.id
             assert favorite.mediationId == mediation.id
             assert favorite.userId == user.id
+
+        @clean_database
+        def when_mediation_id_doest_not_exist(self, app):
+            # Given
+            user = create_user(email='test@email.com')
+            offerer = create_offerer()
+            venue = create_venue(offerer, postal_code='29100', siret='12345678912341')
+            offer = create_offer_with_thing_product(venue, thumb_count=0)
+            recommendation = create_recommendation(offer=offer, user=user, is_clicked=False)
+            PcObject.save(recommendation, user)
+
+            json = {
+                'offerId': humanize(offer.id),
+            }
+
+            # When
+            response = TestClient(app.test_client()).with_auth(user.email).post(
+                f'{API_URL}/favorites',
+                json=json)
+
+            # Then
+            assert response.status_code == 201

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -152,7 +152,11 @@ FAVORITE_INCLUDES = [
 ]
 
 RECOMMENDATION_INCLUDES = [
-    "mediation",
+    "discoveryIdentifier",
+    {
+        "key": "mediation",
+        "sub_joins": ["thumbUrl"]
+    },
     {
         "key": "offer",
         "sub_joins": [
@@ -162,7 +166,6 @@ RECOMMENDATION_INCLUDES = [
             "dateRange",
             "isEvent",
             "isThing",
-            "mediation",
             "stocks",
             {
                 "key": "venue",
@@ -202,16 +205,23 @@ WEBAPP_GET_BOOKING_INCLUDES = [
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
-                    "product",
+                    {
+                        "key": "product",
+                        "sub_joins": ["thumbUrl"]
+                    },
                     "stocks",
                     "venue",
                 ]
             },
-            "mediation",
+            {
+                "key": "mediation",
+                "sub_joins": ["thumbUrl"]
+            },
             "thumbUrl"
         ]
     },
-    "stock"
+    "stock",
+    "thumbUrl"
 ]
 
 WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
@@ -235,11 +245,15 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
                     "venue",
                 ]
             },
-            "mediation",
+            {
+                "key": "mediation",
+                "sub_joins": ["thumbUrl"]
+            },
             "thumbUrl"
         ]
     },
     "stock",
+    "thumbUrl",
     {
         "key": "user",
         "sub_joins": USER_INCLUDES

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -215,6 +215,7 @@ WEBAPP_GET_BOOKING_INCLUDES = [
                     "isFinished",
                     "isFullyBooked",
                     "product",
+                    "stocks",
                     "venue",
                 ]
             },

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -136,6 +136,7 @@ FAVORITE_INCLUDES = [
             "isFinished",
             "isThing",
             "isFullyBooked",
+            "offerType",
             {
                 "key": "product",
                 "sub_joins": ["thumbUrl", "offerType"]
@@ -156,21 +157,22 @@ RECOMMENDATION_INCLUDES = [
     {
         "key": "offer",
         "sub_joins": [
+            "dateRange",
             'favorites',
+            "isEvent",
             'isFinished',
             'isFullyBooked',
-            "dateRange",
-            "isEvent",
             "isThing",
+            "offerType",
+            {
+                "key": "product",
+                "sub_joins": ["thumbUrl", "offerType"]
+            },
             "stocks",
             {
                 "key": "venue",
                 "sub_joins": ["managingOfferer"]
             },
-            {
-                "key": "product",
-                "sub_joins": ["thumbUrl", "offerType"]
-            }
         ]
     },
     "thumbUrl"
@@ -202,6 +204,7 @@ WEBAPP_GET_BOOKING_INCLUDES = [
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
+                    "offerType",
                     {
                         "key": "product",
                         "sub_joins": ["thumbUrl"]
@@ -235,9 +238,10 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
+                    "offerType",
                     {
                         "key": "product",
-                        "sub_joins": ["offerType", "thumbUrl"]
+                        "sub_joins": ["thumbUrl"]
                     },
                     "stocks",
                     "venue",

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -195,6 +195,7 @@ WEBAPP_GET_BOOKING_INCLUDES = [
     {
         "key": "recommendation",
         "sub_joins": [
+            "discoveryIdentifier",
             {
                 "key": "offer",
                 "sub_joins": [
@@ -226,6 +227,7 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
     {
         "key": "recommendation",
         "sub_joins": [
+            "discoveryIdentifier",
             {
                 "key": "offer",
                 "sub_joins": [

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -123,43 +123,32 @@ OFFER_INCLUDES = [
 
 FAVORITE_INCLUDES = [
     "-userId",
-    "mediation",
     {
-        "key": "offer",
-        "sub_joins": [
-            'favorites',
-            'isFinished',
-            'isFullyBooked',
-            "dateRange",
-            "isEvent",
-            "isThing",
-            "mediation",
-            "stocks",
-            {
-                "key": "venue",
-                "sub_joins": ["managingOfferer"]
-            },
-            {
-                "key": "stocks",
-                "sub_joins": ['bookings']
-            },
-            {
-                "key": "product",
-                "sub_joins": ["thumbUrl", "offerType"]
-            }
-        ]
-    },
-    {
-        "key": "recommendation",
+        "key": "mediation",
         "sub_joins": [
             "thumbUrl"
         ]
     },
     {
-        "key": "mediation",
-        "sub_joins": ["thumbUrl"]
+        "key": "offer",
+        "sub_joins": [
+            "dateRange",
+            "favorites",
+            "isEvent",
+            "isFinished",
+            "isThing",
+            "isFullyBooked",
+            {
+                "key": "product",
+                "sub_joins": [
+                    "thumbUrl"
+                ]
+            },
+            "stocks",
+            "venue",
+        ]
     },
-    "isFavorite"
+    "thumbUrl"
 ]
 
 RECOMMENDATION_INCLUDES = [
@@ -185,8 +174,7 @@ RECOMMENDATION_INCLUDES = [
             }
         ]
     },
-    "thumbUrl",
-    "isFavorite"
+    "thumbUrl"
 ]
 
 USER_INCLUDES = [

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -202,7 +202,7 @@ USER_INCLUDES = [
     'wallet_is_activated'
 ]
 
-BOOKING_INCLUDES = [
+WEBAPP_GET_BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
     {
@@ -225,7 +225,28 @@ BOOKING_INCLUDES = [
     "stock"
 ]
 
-BOOKING_WITH_USER_INCLUDES = BOOKING_INCLUDES + [
+WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
+    "completedUrl",
+    "isUserCancellable",
+    {
+        "key": "recommendation",
+        "sub_joins": [
+            {
+                "key": "offer",
+                "sub_joins": [
+                    "favorites",
+                    "isFinished",
+                    "isFullyBooked",
+                    "product",
+                    "stocks",
+                    "venue",
+                ]
+            },
+            "mediation",
+            "thumbUrl"
+        ]
+    },
+    "stock",
     {
         "key": "user",
         "sub_joins": USER_INCLUDES

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -234,10 +234,14 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
             {
                 "key": "offer",
                 "sub_joins": [
+                    "dateRange",
                     "favorites",
                     "isFinished",
                     "isFullyBooked",
-                    "product",
+                    {
+                        "key": "product",
+                        "sub_joins": ["offerType", "thumbUrl"]
+                    },
                     "stocks",
                     "venue",
                 ]

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -125,9 +125,7 @@ FAVORITE_INCLUDES = [
     "-userId",
     {
         "key": "mediation",
-        "sub_joins": [
-            "thumbUrl"
-        ]
+        "sub_joins": ["thumbUrl"]
     },
     {
         "key": "offer",
@@ -140,9 +138,7 @@ FAVORITE_INCLUDES = [
             "isFullyBooked",
             {
                 "key": "product",
-                "sub_joins": [
-                    "thumbUrl"
-                ]
+                "sub_joins": ["thumbUrl", "offerType"]
             },
             "stocks",
             "venue",

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -189,6 +189,19 @@ RECOMMENDATION_INCLUDES = [
     "isFavorite"
 ]
 
+USER_INCLUDES = [
+    '-culturalSurveyId',
+    '-password',
+    '-resetPasswordToken',
+    '-resetPasswordTokenValidityLimit',
+    '-validationToken',
+    'expenses',
+    'hasPhysicalVenues',
+    'hasOffers',
+    'wallet_balance',
+    'wallet_is_activated'
+]
+
 BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
@@ -210,6 +223,13 @@ BOOKING_INCLUDES = [
         ]
     },
     "stock"
+]
+
+BOOKING_WITH_USER_INCLUDES = BOOKING_INCLUDES + [
+    {
+        "key": "user",
+        "sub_joins": USER_INCLUDES
+    }
 ]
 
 PRO_BOOKING_INCLUDES = [
@@ -238,18 +258,6 @@ PRO_BOOKING_INCLUDES = [
             'lastName': element['lastName']
         }),
     }
-]
-
-USER_INCLUDES = [
-    '-culturalSurveyId',
-    '-password',
-    '-resetPasswordToken',
-    '-resetPasswordTokenValidityLimit',
-    '-validationToken',
-    'hasPhysicalVenues',
-    'hasOffers',
-    'wallet_balance',
-    'wallet_is_activated'
 ]
 
 VENUE_INCLUDES = [

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -1,5 +1,3 @@
-""" includes """
-
 OFFERER_INCLUDES = [
     {
         "key": "managedVenues",
@@ -195,21 +193,6 @@ BOOKING_INCLUDES = [
     "completedUrl",
     "isUserCancellable",
     {
-        "key": "stock",
-        "sub_joins":
-            [
-                {
-                    "key": "resolvedOffer",
-                    "sub_joins": [
-                        "product",
-                        "venue",
-                        'isFinished',
-                        'isFullyBooked'
-                    ]
-                }
-            ]
-    },
-    {
         "key": "recommendation",
         "sub_joins": [
             {
@@ -226,6 +209,7 @@ BOOKING_INCLUDES = [
             "thumbUrl"
         ]
     },
+    "stock"
 ]
 
 PRO_BOOKING_INCLUDES = [

--- a/validation/offers.py
+++ b/validation/offers.py
@@ -52,12 +52,11 @@ def check_offer_type_is_valid(offer_type_name):
         raise api_error
 
 
-def check_offer_id_and_mediation_id_are_present_in_request(offer_id: str, mediation_id: str):
-    if offer_id is None \
-            or mediation_id is None:
+def check_offer_id_is_present_in_request(offer_id: str):
+    if offer_id is None:
         errors = ApiErrors()
         errors.status_code = 400
-        errors.add_error('global', "Les paramères offerId et mediationId sont obligatoires")
+        errors.add_error('global', 'Le paramètre offerId est obligatoire')
         errors.maybe_raise()
         raise errors
 


### PR DESCRIPTION
(Reprise de la branche pC-2139-adapted-expenses-and-booking-includes (https://github.com/betagouv/pass-culture-api/pull/719) mais pour l'appeler sour le meme nom que la branche cote webapp afin de lancer les tests end to end avec cet état d'api:) !

La pr correspondante sur webapp a besoin de deux choses:

- mettre la propriété 'expenses' comme property dans le model user pour etre plus consistent avec le reste du code

- faire en sorte que les POST et PATCH /bookings renvoie en meme temps l'objet user, pour pouvoir directement rafraichir le wallet_balance cote front ; et cela sans demander de faire une deuxieme requete get uses/current.

- faire en sorte aussi les POST et PATCH /bookings renvoie d'avantage d'informations sur l'objet recommendation : { offer { offerType } } associé au booking, car sinon cette information est overridée et disparaît au succes de ces requetes, faisant bugger l'action de reserver un booking quand on est sur la page recherche. 

- faire aussi en sorte que GET, POST de /favorites retourne un firstMatchingBooking pour le user afin de l'afficher sur les details du favori