### PR TITLE
(PC-2728) - remove duo offer from feature table

### DIFF
--- a/alembic/versions/284df157db6d_add_reimbursement_by_venue_feature.py
+++ b/alembic/versions/284df157db6d_add_reimbursement_by_venue_feature.py
@@ -5,13 +5,19 @@ Revises: 883df84383c1
 Create Date: 2019-08-14 12:37:43.969998
 
 """
+from enum import Enum
 from alembic import op
 import sqlalchemy as sa
 
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
+
 
 # revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
-
 revision = '284df157db6d'
 down_revision = '883df84383c1'
 branch_labels = None

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -20,9 +20,9 @@ depends_on = None
 new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
 previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
 
-previous_enum = sa.Enum(*previous_values, name='duo_featuretoggle')
-new_enum = sa.Enum(*new_values, name='duo_featuretoggle')
-temporary_enum = sa.Enum(*new_values, name='tmp_duo_featuretoggle')
+previous_enum = sa.Enum(*previous_values, name='featuretoggle')
+new_enum = sa.Enum(*new_values, name='featuretoggle')
+temporary_enum = sa.Enum(*new_values, name='tmp_featuretoggle')
 
 
 def upgrade():
@@ -30,12 +30,12 @@ def upgrade():
 
 def downgrade():
     temporary_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_duo_featuretoggle'
-               ' USING name::text::tmp_duo_featuretoggle')
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_featuretoggle'
+               ' USING name::text::tmp_featuretoggle')
     previous_enum.drop(op.get_bind(), checkfirst=False)
     new_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE duo_featuretoggle'
-               ' USING name::text::duo_featuretoggle')
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle'
+               ' USING name::text::featuretoggle')
     op.execute("""
             INSERT INTO feature (name, description, "isActive")
             VALUES ('%s', '%s', FALSE);

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -25,7 +25,23 @@ class FeatureToggle(Enum):
 
 
 def upgrade():
+    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
+    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
+
     op.execute("DELETE FROM feature WHERE name = 'DUO_OFFER'")
+    previous_enum = sa.Enum(*previous_values, name='featuretoggle')
+    new_enum = sa.Enum(*new_values, name='featuretoggle')
+    temporary_enum = sa.Enum(*previous_values, name='tmp_featuretoggle')
+
+    temporary_enum.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE TMP_FEATURETOGGLE'
+               ' USING name::TEXT::TMP_FEATURETOGGLE')
+    previous_enum.drop(op.get_bind(), checkfirst=False)
+    new_enum.create(op.get_bind(), checkfirst=False)
+
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE FEATURETOGGLE'
+               ' USING name::TEXT::FEATURETOGGLE')
+    temporary_enum.drop(op.get_bind(), checkfirst=False)
 
 
 def downgrade():

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -1,0 +1,43 @@
+"""remove_duo_offer_feature_flag
+
+Revision ID: 2ae0f4147390
+Revises: 75f2ccf2be82
+Create Date: 2019-12-30 09:01:56.770901
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+from models.feature import FeatureToggle
+
+revision = '2ae0f4147390'
+down_revision = '75f2ccf2be82'
+branch_labels = None
+depends_on = None
+
+previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
+new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
+
+previous_enum = sa.Enum(*previous_values, name='featuretoggle')
+new_enum = sa.Enum(*new_values, name='featuretoggle')
+temporary_enum = sa.Enum(*new_values, name='tmp_featuretoggle')
+
+
+def upgrade():
+    op.execute("DELETE FROM feature WHERE name = 'DUO_OFFER'")
+
+def downgrade():
+    temporary_enum.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_featuretoggle'
+               ' USING name::text::tmp_featuretoggle')
+    previous_enum.drop(op.get_bind(), checkfirst=False)
+    new_enum.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle'
+               ' USING name::text::featuretoggle')
+    op.execute("""
+            INSERT INTO feature (name, description, "isActive")
+            VALUES ('%s', '%s', FALSE);
+            """ % (FeatureToggle.DUO_OFFER.name, FeatureToggle.DUO_OFFER.value))
+    temporary_enum.drop(op.get_bind(), checkfirst=False)

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -17,12 +17,12 @@ down_revision = '75f2ccf2be82'
 branch_labels = None
 depends_on = None
 
-previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
-new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
+new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
+previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
 
-previous_enum = sa.Enum(*previous_values, name='featuretoggle')
-new_enum = sa.Enum(*new_values, name='featuretoggle')
-temporary_enum = sa.Enum(*new_values, name='tmp_featuretoggle')
+previous_enum = sa.Enum(*previous_values, name='duo_featuretoggle')
+new_enum = sa.Enum(*new_values, name='duo_featuretoggle')
+temporary_enum = sa.Enum(*new_values, name='tmp_duo_featuretoggle')
 
 
 def upgrade():
@@ -30,12 +30,12 @@ def upgrade():
 
 def downgrade():
     temporary_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_featuretoggle'
-               ' USING name::text::tmp_featuretoggle')
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_duo_featuretoggle'
+               ' USING name::text::tmp_duo_featuretoggle')
     previous_enum.drop(op.get_bind(), checkfirst=False)
     new_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle'
-               ' USING name::text::featuretoggle')
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE duo_featuretoggle'
+               ' USING name::text::duo_featuretoggle')
     op.execute("""
             INSERT INTO feature (name, description, "isActive")
             VALUES ('%s', '%s', FALSE);

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -6,38 +6,18 @@ Create Date: 2019-12-30 09:01:56.770901
 
 """
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
-
 revision = '2ae0f4147390'
 down_revision = '75f2ccf2be82'
 branch_labels = None
 depends_on = None
 
-new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
-previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
-
-previous_enum = sa.Enum(*previous_values, name='featuretoggle')
-new_enum = sa.Enum(*new_values, name='featuretoggle')
-temporary_enum = sa.Enum(*new_values, name='tmp_featuretoggle')
-
-
 def upgrade():
     op.execute("DELETE FROM feature WHERE name = 'DUO_OFFER'")
 
 def downgrade():
-    temporary_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_featuretoggle'
-               ' USING name::text::tmp_featuretoggle')
-    previous_enum.drop(op.get_bind(), checkfirst=False)
-    new_enum.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle'
-               ' USING name::text::featuretoggle')
-    op.execute("""
-            INSERT INTO feature (name, description, "isActive")
-            VALUES ('%s', '%s', FALSE);
-            """ % (FeatureToggle.DUO_OFFER.name, FeatureToggle.DUO_OFFER.value))
-    temporary_enum.drop(op.get_bind(), checkfirst=False)
+      op.execute("""
+      INSERT INTO feature (name, description, "isActive")
+      VALUES ('%s', '%s', FALSE);
+      """ % ('DUO_OFFER', 'Permettre la réservation d’une offre pour soi et un accompagnant'))

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '2ae0f4147390'
-down_revision = '75f2ccf2be82'
+down_revision = '2cb37da9609e'
 branch_labels = None
 depends_on = None
 
@@ -22,11 +22,13 @@ class FeatureToggle(Enum):
     DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
     DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
     QR_CODE = 'Permettre la validation d''une contremarque via QR code'
+    FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE = 'Permet la recherche de mots-clés dans les tables structures' \
+                                                ' et lieux en plus de celles des offres'
 
 
 def upgrade():
-    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
-    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
+    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE', 'FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE')
+    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE', 'FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE')
 
     op.execute("DELETE FROM feature WHERE name = 'DUO_OFFER'")
     previous_enum = sa.Enum(*previous_values, name='featuretoggle')
@@ -45,8 +47,8 @@ def upgrade():
 
 
 def downgrade():
-    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
-    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
+    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE', 'FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE')
+    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE', 'FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE')
 
     previous_enum = sa.Enum(*previous_values, name='featuretoggle')
     new_enum = sa.Enum(*new_values, name='featuretoggle')

--- a/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
+++ b/alembic/versions/2ae0f4147390_remove_duo_offer_feature_flag.py
@@ -5,7 +5,9 @@ Revises: 75f2ccf2be82
 Create Date: 2019-12-30 09:01:56.770901
 
 """
+from enum import Enum
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '2ae0f4147390'
@@ -13,11 +15,37 @@ down_revision = '75f2ccf2be82'
 branch_labels = None
 depends_on = None
 
+
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
+
+
 def upgrade():
     op.execute("DELETE FROM feature WHERE name = 'DUO_OFFER'")
 
+
 def downgrade():
-      op.execute("""
-      INSERT INTO feature (name, description, "isActive")
-      VALUES ('%s', '%s', FALSE);
-      """ % ('DUO_OFFER', 'Permettre la réservation d’une offre pour soi et un accompagnant'))
+    new_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'DUO_OFFER', 'QR_CODE')
+    previous_values = ('WEBAPP_SIGNUP', 'FAVORITE_OFFER', 'DEGRESSIVE_REIMBURSEMENT_RATE', 'QR_CODE')
+
+    previous_enum = sa.Enum(*previous_values, name='featuretoggle')
+    new_enum = sa.Enum(*new_values, name='featuretoggle')
+    temporary_enum = sa.Enum(*new_values, name='tmp_featuretoggle')
+
+    temporary_enum.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE tmp_featuretoggle'
+               ' USING name::text::tmp_featuretoggle')
+    previous_enum.drop(op.get_bind(), checkfirst=False)
+    new_enum.create(op.get_bind(), checkfirst=False)
+
+    op.execute('ALTER TABLE feature ALTER COLUMN name TYPE featuretoggle'
+               ' USING name::text::featuretoggle')
+    op.execute("""
+                INSERT INTO feature (name, description, "isActive")
+                VALUES ('%s', '%s', FALSE);
+                """ % (FeatureToggle.DUO_OFFER.name, FeatureToggle.DUO_OFFER.value))
+    temporary_enum.drop(op.get_bind(), checkfirst=False)

--- a/alembic/versions/37ba62c7fdb3_add_favorite_feature.py
+++ b/alembic/versions/37ba62c7fdb3_add_favorite_feature.py
@@ -5,13 +5,20 @@ Revises: 1a6a6a4baf3b
 Create Date: 2019-07-09 09:47:32.341098
 
 """
+from enum import Enum
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import expression
 
-# revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
 
+
+# revision identifiers, used by Alembic.
 revision = '37ba62c7fdb3'
 down_revision = '1a6a6a4baf3b'
 branch_labels = None

--- a/alembic/versions/8ab840b8db67_add_qr_code_feature.py
+++ b/alembic/versions/8ab840b8db67_add_qr_code_feature.py
@@ -5,13 +5,19 @@ Revises: eda764ae6b37
 Create Date: 2019-10-29 12:57:51.751401
 
 """
+from enum import Enum
 from alembic import op
 import sqlalchemy as sa
 
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
+
 
 # revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
-
 revision = '8ab840b8db67'
 down_revision = 'eda764ae6b37'
 branch_labels = None

--- a/alembic/versions/914fef4f49ab_add_duo_offer_feature_flag.py
+++ b/alembic/versions/914fef4f49ab_add_duo_offer_feature_flag.py
@@ -5,13 +5,19 @@ Revises: 600464fd8ac8
 Create Date: 2019-10-09 12:05:13.610887
 
 """
+from enum import Enum
 from alembic import op
 import sqlalchemy as sa
 
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
+
 
 # revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
-
 revision = '914fef4f49ab'
 down_revision = '600464fd8ac8'
 branch_labels = None

--- a/alembic/versions/d4c38884d642_add_feature_table.py
+++ b/alembic/versions/d4c38884d642_add_feature_table.py
@@ -5,11 +5,17 @@ Revises: e945f921cc69
 Create Date: 2019-03-13 15:05:49.681745
 
 """
+from enum import Enum
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-from models.feature import FeatureToggle
+class FeatureToggle(Enum):
+    WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
+    FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
+    DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
+    QR_CODE = 'Permettre la validation d''une contremarque via QR code'
 
 revision = 'd4c38884d642'
 down_revision = 'e945f921cc69'

--- a/models/feature.py
+++ b/models/feature.py
@@ -11,10 +11,10 @@ class FeatureToggle(enum.Enum):
     WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
     FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
     DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
+    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
     QR_CODE = 'Permettre la validation d''une contremarque via QR code'
     FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE = 'Permet la recherche de mots-clés dans les tables structures' \
                                                 ' et lieux en plus de celles des offres'
-
 
 class Feature(PcObject, Model, DeactivableMixin):
     name = Column(Enum(FeatureToggle), index=True, unique=True, nullable=False)

--- a/models/feature.py
+++ b/models/feature.py
@@ -11,7 +11,6 @@ class FeatureToggle(enum.Enum):
     WEBAPP_SIGNUP = 'Permettre aux bénéficiaires de créer un compte'
     FAVORITE_OFFER = 'Permettre aux bénéficiaires d''ajouter des offres en favoris'
     DEGRESSIVE_REIMBURSEMENT_RATE = 'Permettre le remboursement avec un barème dégressif par lieu'
-    DUO_OFFER = 'Permettre la réservation d’une offre pour soi et un accompagnant'
     QR_CODE = 'Permettre la validation d''une contremarque via QR code'
     FULL_OFFERS_SEARCH_WITH_OFFERER_AND_VENUE = 'Permet la recherche de mots-clés dans les tables structures' \
                                                 ' et lieux en plus de celles des offres'


### PR DESCRIPTION
- suppression de la dépendance à l'enum FeatureGoogle importée depuis le modèle Feature dans toutes les migrations
- simplification du downgrade dans la dernière migration qui supprimer la feature OFFRE_DUO : on insère et on supprimer l'énum de la table feature. 