### PR TITLE
add werkzeug package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,5 +68,6 @@ sqlparse==0.3.0
 simplejson==3.16.0
 schwifty==2018.9.1
 urllib3==1.25.7
+werkzeug==0.16.0
 wetransferpy==0.2.3
 xlrd==1.2.0


### PR DESCRIPTION
La CI était rouge car Flask appelait la dernière version de ce package.
Je l'ai donc fixé.
https://circleci.com/gh/betagouv/pass-culture-api/8363