### PR TITLE
(PC-3175) adapted recommendations/v3 for when user is not assigned to an iris

### DIFF
--- a/recommendations_engine/recommendations.py
+++ b/recommendations_engine/recommendations.py
@@ -1,6 +1,6 @@
 import random
 from datetime import timedelta
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import dateutil.parser
 
@@ -22,7 +22,7 @@ from validation.routes.recommendations import check_distance_is_digit, \
 MAX_OF_MAX_DISTANCE = "20000"
 
 
-#TODO remove this function and its tests once v3 is the only route
+# TODO remove this function and its tests once v3 is the only route
 def give_requested_recommendation_to_user(user, offer_id, mediation_id):
     recommendation = None
 
@@ -110,9 +110,8 @@ def create_recommendations_for_discovery_v2(user: User,
     return recommendations
 
 
-def create_recommendations_for_discovery_v3(user: User,
-                                            user_iris_id: int = None,
-                                            seen_recommendation_ids: List[int] = [],
+def create_recommendations_for_discovery_v3(user: User, user_iris_id: Optional[int] = None,
+                                            user_is_geolocated: bool = False, seen_recommendation_ids: List[int] = [],
                                             limit: int = 3) -> List[Recommendation]:
     recommendations = []
     tuto_mediations_by_index = {}
@@ -126,7 +125,8 @@ def create_recommendations_for_discovery_v3(user: User,
                                                                      limit=max_tuto_index)
 
     inserted_tuto_mediations = 0
-    offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_iris_id, limit=limit,
+    offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_iris_id,
+                                              user_is_geolocated=user_is_geolocated, limit=limit,
                                               seen_recommendation_ids=seen_recommendation_ids)
 
     for (index, offer) in enumerate(offers):

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -168,6 +168,7 @@ def put_recommendations_v3():
     json_keys = request.json.keys()
     latitude = request.args.get('latitude')
     longitude = request.args.get('longitude')
+    user_is_geolocated = latitude is not None and longitude is not None
     user_iris_id = get_iris_containing_user_location(latitude, longitude) if latitude and longitude else None
 
     if 'readRecommendations' in json_keys:
@@ -180,10 +181,11 @@ def put_recommendations_v3():
     else:
         seen_recommendation_ids = []
 
-    created_recommendations = create_recommendations_for_discovery_v3(limit=BLOB_SIZE,
-                                                                      user=current_user,
+    created_recommendations = create_recommendations_for_discovery_v3(user=current_user,
                                                                       user_iris_id=user_iris_id,
-                                                                      seen_recommendation_ids=seen_recommendation_ids)
+                                                                      user_is_geolocated=user_is_geolocated,
+                                                                      seen_recommendation_ids=seen_recommendation_ids,
+                                                                      limit=BLOB_SIZE)
 
     recommendations = move_tutorial_recommendations_first(created_recommendations,
                                                           seen_recommendation_ids,

--- a/tests/repository/get_offers_for_recommendation_v3_test.py
+++ b/tests/repository/get_offers_for_recommendation_v3_test.py
@@ -29,19 +29,13 @@ class GetOffersForRecommendationV3Test:
         mediation1 = create_mediation(stock.offer)
         mediation2 = create_mediation(stock_activation.offer)
 
-        polygon = POLYGON_TEST
 
-        user_location_iris = create_iris(polygon)
         repository.save(user, stock, stock_activation, mediation1, mediation2)
-
-        iris_venue = create_iris_venue(user_location_iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=user_location_iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offer in offers
@@ -61,19 +55,12 @@ class GetOffersForRecommendationV3Test:
         create_mediation(stock_93.offer)
         create_mediation(stock_activation_93.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock_93, stock_activation_93)
-
-        iris_venue = create_iris_venue(iris, venue_93)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offer_93 in offers
@@ -91,19 +78,12 @@ class GetOffersForRecommendationV3Test:
         stock = create_stock_from_offer(offer, available=2)
         create_mediation(stock.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert len(offers) == 1
@@ -118,19 +98,13 @@ class GetOffersForRecommendationV3Test:
         stock2 = create_stock_with_thing_offer(offerer, venue, name='thing_without_mediation')
         create_mediation(stock1.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock1, stock2)
 
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert len(offers) == 1
@@ -160,19 +134,12 @@ class GetOffersForRecommendationV3Test:
         create_mediation(stock2.offer)
         create_mediation(stock3.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock1, stock2, stock3)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert len(offers) == 3
@@ -202,13 +169,7 @@ class GetOffersForRecommendationV3Test:
         create_mediation(stock5.offer)
         create_mediation(stock6.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock1, stock2, stock3, stock4, stock5, stock6, user)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
@@ -217,8 +178,7 @@ class GetOffersForRecommendationV3Test:
                             for o in offers[:4]])) == 4
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert len(offers) == 6
@@ -237,19 +197,12 @@ class GetOffersForRecommendationV3Test:
         booking2 = create_booking(user=user, stock=stock, quantity=2, venue=venue)
         create_mediation(stock.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, booking1, booking2)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert len(offers) == 0
@@ -272,19 +225,12 @@ class GetOffersForRecommendationV3Test:
         create_mediation(stock1.offer)
         create_mediation(stock2.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock1, stock2)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offers == [offer2, offer1]
@@ -312,19 +258,12 @@ class GetOffersForRecommendationV3Test:
         create_mediation(stock2.offer)
         create_mediation(stock3.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock1, stock2, stock3)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offers == [offer2, offer3, offer1]
@@ -340,19 +279,12 @@ class GetOffersForRecommendationV3Test:
         booking = create_booking(user=user, stock=stock)
         create_mediation(stock.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, booking)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offers == []
@@ -369,22 +301,104 @@ class GetOffersForRecommendationV3Test:
         mediation = create_mediation(stock.offer)
         favorite = create_favorite(mediation=mediation, offer=offer, user=user)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, favorite)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
         # Then
         assert offers == []
+
+    @clean_database
+    def test_should_not_return_offers_having_only_soft_deleted_stocks(self, app):
+        # Given
+        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+        offerer = create_offerer()
+        user = create_user()
+        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                             latitude=49.894171)
+        offer = create_offer_with_thing_product(venue=venue, product=product)
+        stock = create_stock_from_offer(offer, available=2, soft_deleted=True)
+        create_mediation(stock.offer)
+
+        repository.save(user, stock)
+
+        DiscoveryView.refresh(concurrently=False)
+
+        # When
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+        # Then
+        assert len(offers) == 0
+
+    @clean_database
+    def test_should_not_return_offers_from_non_validated_venue(self, app):
+        # Given
+        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+        offerer = create_offerer()
+        user = create_user()
+        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                             latitude=49.894171, validation_token='nimportequoi')
+        offer = create_offer_with_thing_product(venue=venue, product=product)
+        stock = create_stock_from_offer(offer, available=2)
+        create_mediation(stock.offer)
+
+        repository.save(user, stock)
+
+        DiscoveryView.refresh(concurrently=False)
+
+        # When
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+        # Then
+        assert len(offers) == 0
+
+    @clean_database
+    def test_should_not_return_offers_from_non_validated_offerers(self, app):
+        # Given
+        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+        offerer = create_offerer(validation_token='nimportequoi')
+        user = create_user()
+        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                             latitude=49.894171)
+        offer = create_offer_with_thing_product(venue=venue, product=product)
+        stock = create_stock_from_offer(offer, available=2)
+        create_mediation(stock.offer)
+
+        repository.save(user, stock)
+
+        DiscoveryView.refresh(concurrently=False)
+
+        # When
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+        # Then
+        assert len(offers) == 0
+
+    @clean_database
+    def test_should_not_return_offers_having_only_stocks_with_past_booking_limit_date_time(self, app):
+        # Given
+        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+        offerer = create_offerer()
+        user = create_user()
+        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                             latitude=49.894171)
+        offer = create_offer_with_thing_product(venue=venue, product=product)
+        one_day_ago = datetime.utcnow() - timedelta(days=1)
+        stock = create_stock_from_offer(offer, available=2, booking_limit_datetime=one_day_ago)
+        create_mediation(stock.offer)
+
+        repository.save(user, stock)
+
+        DiscoveryView.refresh(concurrently=False)
+
+        # When
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+        # Then
+        assert len(offers) == 0
 
     @clean_database
     def test_should_not_return_offers_from_venue_outside_user_iris(self, app):
@@ -410,8 +424,8 @@ class GetOffersForRecommendationV3Test:
         DiscoveryView.refresh(concurrently=False)
 
         # when
-        offers = get_offers_for_recommendation_v3(user_iris_id=user_location_iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
+                                                  user_is_geolocated=True)
 
         # then
         assert offers == []
@@ -440,126 +454,57 @@ class GetOffersForRecommendationV3Test:
         DiscoveryView.refresh(concurrently=False)
 
         # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=user_location_iris.id,
-                                                  user=user)
+        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
+                                                  user_is_geolocated=True)
 
         # Then
         assert offers == [offer]
 
     @clean_database
-    def test_should_not_return_offers_having_only_soft_deleted_stocks(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
+    def test_should_return_offers_regardless_of_location_when_user_is_not_geolocated(self, app):
+        # given
+        offerer = create_offerer(siren='123456789')
         user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2, soft_deleted=True)
+        venue = create_venue(offerer)
+        offer = create_offer_with_thing_product(venue)
+        stock = create_stock_from_offer(offer)
         create_mediation(stock.offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
         repository.save(user, stock)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
 
         DiscoveryView.refresh(concurrently=False)
 
-        # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        # when
+        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
-        # Then
-        assert len(offers) == 0
+        # then
+        assert len(offers) == 1
 
     @clean_database
-    def test_should_not_return_offers_from_non_validated_venue(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
+    def test_should_return_only_national_offers_when_user_is_geolocated_outside_iris(self, app):
+        # given
+        offerer = create_offerer(siren='123456789')
         user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171, validation_token='nimportequoi')
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2)
-        create_mediation(stock.offer)
+        venue = create_venue(offerer)
+        virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
+        offer = create_offer_with_thing_product(venue)
+        digital_offer = create_offer_with_thing_product(virtual_venue, thing_type=ThingType.MUSIQUE, url='https://url.com', is_national=True)
+        national_offer = create_offer_with_thing_product(venue, is_national=True)
+        stock = create_stock_from_offer(offer)
+        stock_on_digital_offer = create_stock_from_offer(digital_offer)
+        stock_on_national_offer = create_stock_from_offer(national_offer)
+        create_mediation(offer)
+        create_mediation(digital_offer)
+        create_mediation(national_offer)
 
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
-        repository.save(user, stock)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
+        repository.save(user, stock, stock_on_digital_offer, stock_on_national_offer)
 
         DiscoveryView.refresh(concurrently=False)
 
-        # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
+        # when
+        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=None, user_is_geolocated=True)
 
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_from_non_validated_offerers(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer(validation_token='nimportequoi')
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2)
-        create_mediation(stock.offer)
-
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
-        repository.save(user, stock)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_having_only_stocks_with_past_booking_limit_date_time(self,app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        one_day_ago = datetime.utcnow() - timedelta(days=1)
-        stock = create_stock_from_offer(offer, available=2, booking_limit_datetime=one_day_ago)
-        create_mediation(stock.offer)
-
-        polygon = POLYGON_TEST
-
-        iris = create_iris(polygon)
-        repository.save(user, stock)
-
-        iris_venue = create_iris_venue(iris, venue)
-        repository.save(iris_venue)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user_iris_id=iris.id,
-                                                  user=user)
-
-        # Then
-        assert len(offers) == 0
-
+        # then
+        assert len(offers) == 2
+        assert digital_offer in offers
+        assert national_offer in offers

--- a/tests/repository/get_offers_for_recommendation_v3_test.py
+++ b/tests/repository/get_offers_for_recommendation_v3_test.py
@@ -15,496 +15,506 @@ from tests.test_utils import POLYGON_TEST
 
 
 class GetOffersForRecommendationV3Test:
-    @clean_database
-    def test_should_not_return_activation_event(self, app):
-        # Given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue = create_venue(offerer)
-        offer = create_offer_with_event_product(venue)
-        offer_activation = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
-
-        stock = create_stock_from_offer(offer)
-        stock_activation = create_stock_from_offer(offer_activation)
-        mediation1 = create_mediation(stock.offer)
-        mediation2 = create_mediation(stock_activation.offer)
-
-
-        repository.save(user, stock, stock_activation, mediation1, mediation2)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offer in offers
-        assert offer_activation not in offers
-
-    @clean_database
-    def test_should_not_return_activation_thing(self, app):
-        # Given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue_93 = create_venue(offerer, postal_code='93000', departement_code='93', siret=offerer.siren + '33333')
-        offer_93 = create_offer_with_thing_product(venue_93, thumb_count=1)
-        offer_activation_93 = create_offer_with_thing_product(venue_93, thing_type=ThingType.ACTIVATION,
-                                                              thumb_count=1)
-        stock_93 = create_stock_from_offer(offer_93)
-        stock_activation_93 = create_stock_from_offer(offer_activation_93)
-        create_mediation(stock_93.offer)
-        create_mediation(stock_activation_93.offer)
-
-        repository.save(user, stock_93, stock_activation_93)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offer_93 in offers
-        assert offer_activation_93 not in offers
-
-    @clean_database
-    def test_should_return_offers_with_stock(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 1
-
-    @clean_database
-    def test_should_return_offers_with_mediation_only(app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-        stock1 = create_stock_with_thing_offer(offerer, venue, name='thing_with_mediation')
-        stock2 = create_stock_with_thing_offer(offerer, venue, name='thing_without_mediation')
-        create_mediation(stock1.offer)
-
-        repository.save(user, stock1, stock2)
-
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 1
-        assert offers[0].name == 'thing_with_mediation'
-
-    @clean_database
-    def test_should_return_offers_that_occur_in_less_than_10_days_and_things_first(self, app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-
-        stock1 = create_stock_with_thing_offer(offerer, venue, name='thing')
-        stock2 = create_stock_with_event_offer(offerer,
-                                               venue,
-                                               beginning_datetime=datetime.utcnow() + timedelta(days=4),
-                                               end_datetime=datetime.utcnow() + timedelta(days=4, hours=2),
-                                               name='event_occurs_soon',
-                                               thumb_count=1)
-        stock3 = create_stock_with_event_offer(offerer,
-                                               venue,
-                                               beginning_datetime=datetime.utcnow() + timedelta(days=11),
-                                               end_datetime=datetime.utcnow() + timedelta(days=11, hours=2),
-                                               name='event_occurs_later',
-                                               thumb_count=1)
-        create_mediation(stock1.offer)
-        create_mediation(stock2.offer)
-        create_mediation(stock3.offer)
-
-        repository.save(user, stock1, stock2, stock3)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 3
-        assert (offers[0].name == 'event_occurs_soon'
-                and offers[1].name == 'thing') \
-               or (offers[1].name == 'event_occurs_soon'
-                   and offers[0].name == 'thing')
-        assert offers[2].name == 'event_occurs_later'
-
-    @clean_database
-    def test_should_return_offers_with_varying_types(self, app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-        stock1 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
-        stock2 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.CINEMA_ABO,
-                                               url='http://example.com')
-        stock3 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
-        stock4 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
-        stock5 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.AUDIOVISUEL)
-        stock6 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX)
-        create_mediation(stock1.offer)
-        create_mediation(stock2.offer)
-        create_mediation(stock3.offer)
-        create_mediation(stock4.offer)
-        create_mediation(stock5.offer)
-        create_mediation(stock6.offer)
-
-        repository.save(user, stock1, stock2, stock3, stock4, stock5, stock6, user)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        def _first_four_offers_have_different_type_and_onlineness(offers):
-            return len(set([o.type + (o.url or '')
-                            for o in offers[:4]])) == 4
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 6
-        assert _first_four_offers_have_different_type_and_onlineness(offers)
-
-    @clean_database
-    def test_should_not_return_offers_with_no_stock(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2, price=0)
-        booking1 = create_booking(user=user, stock=stock, is_cancelled=True, quantity=2, venue=venue)
-        booking2 = create_booking(user=user, stock=stock, quantity=2, venue=venue)
-        create_mediation(stock.offer)
-
-        repository.save(user, booking1, booking2)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_with_criteria_should_return_offer_with_highest_base_score_first(self, app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-
-        offer1 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
-        stock1 = create_stock_from_offer(offer1, price=0)
-        offer1.criteria = [create_criterion(name='negative', score_delta=-1)]
-
-        offer2 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
-        stock2 = create_stock_from_offer(offer2, price=0)
-        offer2.criteria = [create_criterion(name='positive', score_delta=1)]
-
-        create_mediation(stock1.offer)
-        create_mediation(stock2.offer)
-
-        repository.save(user, stock1, stock2)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offers == [offer2, offer1]
-
-    @clean_database
-    def test_with_criteria_should_return_offer_with_highest_base_score_first_bust_keep_the_partition(self, app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-
-        offer1 = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO, thumb_count=1)
-        stock1 = create_stock_from_offer(offer1, price=0)
-        offer1.criteria = [create_criterion(name='negative', score_delta=1)]
-
-        offer2 = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO, thumb_count=1)
-        stock2 = create_stock_from_offer(offer2, price=0)
-        offer2.criteria = [create_criterion(name='positive', score_delta=2)]
-
-        offer3 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
-        stock3 = create_stock_from_offer(offer3, price=0)
-        offer3.criteria = []
-
-        create_mediation(stock1.offer)
-        create_mediation(stock2.offer)
-        create_mediation(stock3.offer)
-
-        repository.save(user, stock1, stock2, stock3)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offers == [offer2, offer3, offer1]
-
-    @clean_database
-    def test_should_not_return_booked_offers(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-        offer = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO)
-        stock = create_stock_from_offer(offer, price=0)
-        user = create_user()
-        booking = create_booking(user=user, stock=stock)
-        create_mediation(stock.offer)
-
-        repository.save(user, booking)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offers == []
-
-    @clean_database
-    def test_should_not_return_favorite_offers(self, app):
-        # Given
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34')
-
-        offer = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO)
-        stock = create_stock_from_offer(offer, price=0)
-        mediation = create_mediation(stock.offer)
-        favorite = create_favorite(mediation=mediation, offer=offer, user=user)
-
-        repository.save(user, favorite)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert offers == []
-
-    @clean_database
-    def test_should_not_return_offers_having_only_soft_deleted_stocks(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2, soft_deleted=True)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_from_non_validated_venue(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171, validation_token='nimportequoi')
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_from_non_validated_offerers(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer(validation_token='nimportequoi')
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        stock = create_stock_from_offer(offer, available=2)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_having_only_stocks_with_past_booking_limit_date_time(self, app):
-        # Given
-        product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
-        offerer = create_offerer()
-        user = create_user()
-        venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
-                             latitude=49.894171)
-        offer = create_offer_with_thing_product(venue=venue, product=product)
-        one_day_ago = datetime.utcnow() - timedelta(days=1)
-        stock = create_stock_from_offer(offer, available=2, booking_limit_datetime=one_day_ago)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # Then
-        assert len(offers) == 0
-
-    @clean_database
-    def test_should_not_return_offers_from_venue_outside_user_iris(self, app):
-        # given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue = create_venue(offerer)
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock_from_offer(offer)
-        create_mediation(stock.offer)
-
-        polygon = POLYGON_TEST
-        polygon2 = Polygon([(2.195693, 50), (2.195693, 48), (2.595697, 48), (2.595697, 50)])
-
-        venue_location_iris = create_iris(polygon)
-        user_location_iris = create_iris(polygon2)
-
-        repository.save(user, stock)
-
-        iris_venue = create_iris_venue(venue_location_iris, venue)
-        repository.save(iris_venue)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # when
-        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
-                                                  user_is_geolocated=True)
-
-        # then
-        assert offers == []
-
-    @clean_database
-    def test_should_return_offer_when_offer_is_national(self, app):
-        # Given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue = create_venue(offerer)
-        offer = create_offer_with_thing_product(venue, is_national=True)
-        stock = create_stock_from_offer(offer)
-        create_mediation(stock.offer)
-
-        polygon = POLYGON_TEST
-        polygon2 = Polygon([(2.195693, 50), (2.195693, 48), (2.595697, 48), (2.595697, 50)])
-
-        venue_location_iris = create_iris(polygon)
-        user_location_iris = create_iris(polygon2)
-
-        repository.save(user, stock)
-
-        iris_venue = create_iris_venue(venue_location_iris, venue)
-        repository.save(iris_venue)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # When
-        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
-                                                  user_is_geolocated=True)
-
-        # Then
-        assert offers == [offer]
-
-    @clean_database
-    def test_should_return_offers_regardless_of_location_when_user_is_not_geolocated(self, app):
-        # given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue = create_venue(offerer)
-        offer = create_offer_with_thing_product(venue)
-        stock = create_stock_from_offer(offer)
-        create_mediation(stock.offer)
-
-        repository.save(user, stock)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # when
-        offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
-
-        # then
-        assert len(offers) == 1
-
-    @clean_database
-    def test_should_return_only_national_offers_when_user_is_geolocated_outside_iris(self, app):
-        # given
-        offerer = create_offerer(siren='123456789')
-        user = create_user()
-        venue = create_venue(offerer)
-        virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
-        offer = create_offer_with_thing_product(venue)
-        digital_offer = create_offer_with_thing_product(virtual_venue, thing_type=ThingType.MUSIQUE, url='https://url.com', is_national=True)
-        national_offer = create_offer_with_thing_product(venue, is_national=True)
-        stock = create_stock_from_offer(offer)
-        stock_on_digital_offer = create_stock_from_offer(digital_offer)
-        stock_on_national_offer = create_stock_from_offer(national_offer)
-        create_mediation(offer)
-        create_mediation(digital_offer)
-        create_mediation(national_offer)
-
-        repository.save(user, stock, stock_on_digital_offer, stock_on_national_offer)
-
-        DiscoveryView.refresh(concurrently=False)
-
-        # when
-        offers = get_offers_for_recommendation_v3(user=user, user_iris_id=None, user_is_geolocated=True)
-
-        # then
-        assert len(offers) == 2
-        assert digital_offer in offers
-        assert national_offer in offers
+    class UniversalBehaviorTest:
+        @clean_database
+        def test_should_not_return_activation_event(self, app):
+            # Given
+            offerer = create_offerer(siren='123456789')
+            user = create_user()
+            venue = create_venue(offerer)
+            offer = create_offer_with_event_product(venue)
+            offer_activation = create_offer_with_event_product(venue, event_type=EventType.ACTIVATION)
+
+            stock = create_stock_from_offer(offer)
+            stock_activation = create_stock_from_offer(offer_activation)
+            mediation1 = create_mediation(stock.offer)
+            mediation2 = create_mediation(stock_activation.offer)
+
+
+            repository.save(user, stock, stock_activation, mediation1, mediation2)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offer in offers
+            assert offer_activation not in offers
+
+        @clean_database
+        def test_should_not_return_activation_thing(self, app):
+            # Given
+            offerer = create_offerer(siren='123456789')
+            user = create_user()
+            venue_93 = create_venue(offerer, postal_code='93000', departement_code='93', siret=offerer.siren + '33333')
+            offer_93 = create_offer_with_thing_product(venue_93, thumb_count=1)
+            offer_activation_93 = create_offer_with_thing_product(venue_93, thing_type=ThingType.ACTIVATION,
+                                                                  thumb_count=1)
+            stock_93 = create_stock_from_offer(offer_93)
+            stock_activation_93 = create_stock_from_offer(offer_activation_93)
+            create_mediation(stock_93.offer)
+            create_mediation(stock_activation_93.offer)
+
+            repository.save(user, stock_93, stock_activation_93)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offer_93 in offers
+            assert offer_activation_93 not in offers
+
+        @clean_database
+        def test_should_return_offers_with_stock(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                                 latitude=49.894171)
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            stock = create_stock_from_offer(offer, available=2)
+            create_mediation(stock.offer)
+
+            repository.save(user, stock)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 1
+
+        @clean_database
+        def test_should_return_offers_with_mediation_only(app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+            stock1 = create_stock_with_thing_offer(offerer, venue, name='thing_with_mediation')
+            stock2 = create_stock_with_thing_offer(offerer, venue, name='thing_without_mediation')
+            create_mediation(stock1.offer)
+
+            repository.save(user, stock1, stock2)
+
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 1
+            assert offers[0].name == 'thing_with_mediation'
+
+        @clean_database
+        def test_should_return_offers_that_occur_in_less_than_10_days_and_things_first(self, app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+
+            stock1 = create_stock_with_thing_offer(offerer, venue, name='thing')
+            stock2 = create_stock_with_event_offer(offerer,
+                                                   venue,
+                                                   beginning_datetime=datetime.utcnow() + timedelta(days=4),
+                                                   end_datetime=datetime.utcnow() + timedelta(days=4, hours=2),
+                                                   name='event_occurs_soon',
+                                                   thumb_count=1)
+            stock3 = create_stock_with_event_offer(offerer,
+                                                   venue,
+                                                   beginning_datetime=datetime.utcnow() + timedelta(days=11),
+                                                   end_datetime=datetime.utcnow() + timedelta(days=11, hours=2),
+                                                   name='event_occurs_later',
+                                                   thumb_count=1)
+            create_mediation(stock1.offer)
+            create_mediation(stock2.offer)
+            create_mediation(stock3.offer)
+
+            repository.save(user, stock1, stock2, stock3)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 3
+            assert (offers[0].name == 'event_occurs_soon'
+                    and offers[1].name == 'thing') \
+                   or (offers[1].name == 'event_occurs_soon'
+                       and offers[0].name == 'thing')
+            assert offers[2].name == 'event_occurs_later'
+
+        @clean_database
+        def test_should_return_offers_with_varying_types(self, app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+            stock1 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
+            stock2 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.CINEMA_ABO,
+                                                   url='http://example.com')
+            stock3 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
+            stock4 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX_VIDEO)
+            stock5 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.AUDIOVISUEL)
+            stock6 = create_stock_with_thing_offer(offerer, venue, name='thing', thing_type=ThingType.JEUX)
+            create_mediation(stock1.offer)
+            create_mediation(stock2.offer)
+            create_mediation(stock3.offer)
+            create_mediation(stock4.offer)
+            create_mediation(stock5.offer)
+            create_mediation(stock6.offer)
+
+            repository.save(user, stock1, stock2, stock3, stock4, stock5, stock6, user)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            def _first_four_offers_have_different_type_and_onlineness(offers):
+                return len(set([o.type + (o.url or '')
+                                for o in offers[:4]])) == 4
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 6
+            assert _first_four_offers_have_different_type_and_onlineness(offers)
+
+        @clean_database
+        def test_should_not_return_offers_with_no_stock(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            stock = create_stock_from_offer(offer, available=2, price=0)
+            booking1 = create_booking(user=user, stock=stock, is_cancelled=True, quantity=2, venue=venue)
+            booking2 = create_booking(user=user, stock=stock, quantity=2, venue=venue)
+            create_mediation(stock.offer)
+
+            repository.save(user, booking1, booking2)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 0
+
+        @clean_database
+        def test_with_criteria_should_return_offer_with_highest_base_score_first(self, app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+
+            offer1 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
+            stock1 = create_stock_from_offer(offer1, price=0)
+            offer1.criteria = [create_criterion(name='negative', score_delta=-1)]
+
+            offer2 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
+            stock2 = create_stock_from_offer(offer2, price=0)
+            offer2.criteria = [create_criterion(name='positive', score_delta=1)]
+
+            create_mediation(stock1.offer)
+            create_mediation(stock2.offer)
+
+            repository.save(user, stock1, stock2)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offers == [offer2, offer1]
+
+        @clean_database
+        def test_with_criteria_should_return_offer_with_highest_base_score_first_bust_keep_the_partition(self, app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+
+            offer1 = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO, thumb_count=1)
+            stock1 = create_stock_from_offer(offer1, price=0)
+            offer1.criteria = [create_criterion(name='negative', score_delta=1)]
+
+            offer2 = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO, thumb_count=1)
+            stock2 = create_stock_from_offer(offer2, price=0)
+            offer2.criteria = [create_criterion(name='positive', score_delta=2)]
+
+            offer3 = create_offer_with_thing_product(venue, thing_type=ThingType.JEUX_VIDEO, thumb_count=1)
+            stock3 = create_stock_from_offer(offer3, price=0)
+            offer3.criteria = []
+
+            create_mediation(stock1.offer)
+            create_mediation(stock2.offer)
+            create_mediation(stock3.offer)
+
+            repository.save(user, stock1, stock2, stock3)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offers == [offer2, offer3, offer1]
+
+        @clean_database
+        def test_should_not_return_offers_having_only_soft_deleted_stocks(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                                 latitude=49.894171)
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            stock = create_stock_from_offer(offer, available=2, soft_deleted=True)
+            create_mediation(stock.offer)
+
+            repository.save(user, stock)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 0
+
+        @clean_database
+        def test_should_not_return_offers_from_non_validated_venue(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                                 latitude=49.894171, validation_token='nimportequoi')
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            stock = create_stock_from_offer(offer, available=2)
+            create_mediation(stock.offer)
+
+            repository.save(user, stock)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 0
+
+        @clean_database
+        def test_should_not_return_offers_from_non_validated_offerers(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer(validation_token='nimportequoi')
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                                 latitude=49.894171)
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            stock = create_stock_from_offer(offer, available=2)
+            create_mediation(stock.offer)
+
+            repository.save(user, stock)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 0
+
+        @clean_database
+        def test_should_not_return_offers_having_only_stocks_with_past_booking_limit_date_time(self, app):
+            # Given
+            product = create_product_with_thing_type(thing_name='Lire un livre', is_national=True)
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34', longitude=2.295695,
+                                 latitude=49.894171)
+            offer = create_offer_with_thing_product(venue=venue, product=product)
+            one_day_ago = datetime.utcnow() - timedelta(days=1)
+            stock = create_stock_from_offer(offer, available=2, booking_limit_datetime=one_day_ago)
+            create_mediation(stock.offer)
+
+            repository.save(user, stock)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert len(offers) == 0
+
+    class UserSpecificBehaviorTest:
+
+        @clean_database
+        def test_should_not_return_booked_offers(self, app):
+            # Given
+            offerer = create_offerer()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+            offer = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO)
+            stock = create_stock_from_offer(offer, price=0)
+            user = create_user()
+            booking = create_booking(user=user, stock=stock)
+            create_mediation(stock.offer)
+
+            repository.save(user, booking)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offers == []
+
+        @clean_database
+        def test_should_not_return_favorite_offers(self, app):
+            # Given
+            offerer = create_offerer()
+            user = create_user()
+            venue = create_venue(offerer, postal_code='34000', departement_code='34')
+
+            offer = create_offer_with_thing_product(venue, thing_type=ThingType.CINEMA_ABO)
+            stock = create_stock_from_offer(offer, price=0)
+            mediation = create_mediation(stock.offer)
+            favorite = create_favorite(mediation=mediation, offer=offer, user=user)
+
+            repository.save(user, favorite)
+
+            DiscoveryView.refresh(concurrently=False)
+
+            # When
+            offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+            # Then
+            assert offers == []
+
+        class WhenUserIsGeolocatedTest:
+
+            @clean_database
+            def test_should_return_offer_when_offer_is_national(self, app):
+                # Given
+                offerer = create_offerer(siren='123456789')
+                user = create_user()
+                venue = create_venue(offerer)
+                offer = create_offer_with_thing_product(venue, is_national=True)
+                stock = create_stock_from_offer(offer)
+                create_mediation(stock.offer)
+
+                polygon = POLYGON_TEST
+                polygon2 = Polygon([(2.195693, 50), (2.195693, 48), (2.595697, 48), (2.595697, 50)])
+
+                venue_location_iris = create_iris(polygon)
+                user_location_iris = create_iris(polygon2)
+
+                repository.save(user, stock)
+
+                iris_venue = create_iris_venue(venue_location_iris, venue)
+                repository.save(iris_venue)
+
+                DiscoveryView.refresh(concurrently=False)
+
+                # When
+                offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
+                                                          user_is_geolocated=True)
+
+                # Then
+                assert offers == [offer]
+
+            @clean_database
+            def test_should_not_return_offers_from_venue_outside_user_iris(self, app):
+                # given
+                offerer = create_offerer(siren='123456789')
+                user = create_user()
+                venue = create_venue(offerer)
+                offer = create_offer_with_thing_product(venue)
+                stock = create_stock_from_offer(offer)
+                create_mediation(stock.offer)
+
+                polygon = POLYGON_TEST
+                polygon2 = Polygon([(2.195693, 50), (2.195693, 48), (2.595697, 48), (2.595697, 50)])
+
+                venue_location_iris = create_iris(polygon)
+                user_location_iris = create_iris(polygon2)
+
+                repository.save(user, stock)
+
+                iris_venue = create_iris_venue(venue_location_iris, venue)
+                repository.save(iris_venue)
+
+                DiscoveryView.refresh(concurrently=False)
+
+                # when
+                offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
+                                                          user_is_geolocated=True)
+
+                # then
+                assert offers == []
+
+            @clean_database
+            def test_should_return_only_national_offers_when_user_is_geolocated_abroad(self, app):
+                # given
+                offerer = create_offerer(siren='123456789')
+                user = create_user()
+                venue = create_venue(offerer)
+                virtual_venue = create_venue(offerer, is_virtual=True, siret=None)
+                offer = create_offer_with_thing_product(venue)
+                digital_offer = create_offer_with_thing_product(virtual_venue, thing_type=ThingType.MUSIQUE,
+                                                                url='https://url.com', is_national=True)
+                national_offer = create_offer_with_thing_product(venue, is_national=True)
+                stock = create_stock_from_offer(offer)
+                stock_on_digital_offer = create_stock_from_offer(digital_offer)
+                stock_on_national_offer = create_stock_from_offer(national_offer)
+                create_mediation(offer)
+                create_mediation(digital_offer)
+                create_mediation(national_offer)
+
+                repository.save(user, stock, stock_on_digital_offer, stock_on_national_offer)
+
+                DiscoveryView.refresh(concurrently=False)
+
+                # when
+                offers = get_offers_for_recommendation_v3(user=user, user_iris_id=None, user_is_geolocated=True)
+
+                # then
+                assert len(offers) == 2
+                assert digital_offer in offers
+                assert national_offer in offers
+
+        class WhenUserIsNotGeolocatedTest:
+
+            @clean_database
+            def test_should_return_offers_regardless_of_location(self, app):
+                # given
+                offerer = create_offerer(siren='123456789')
+                user = create_user()
+                venue = create_venue(offerer)
+                offer = create_offer_with_thing_product(venue)
+                stock = create_stock_from_offer(offer)
+                create_mediation(stock.offer)
+
+                repository.save(user, stock)
+
+                DiscoveryView.refresh(concurrently=False)
+
+                # when
+                offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
+
+                # then
+                assert len(offers) == 1
+
+


### PR DESCRIPTION
1) if user is not geolocated, return offers regardless of location. 
2) When user is geolocated but does not match iris, return only national offers