### PR TITLE
(pC-3194) discovery view ordered by digital offers

### DIFF
--- a/alembic/versions/2b44409d9f54_create_get_recommendable_offers_ordered_by_digital_offers.py
+++ b/alembic/versions/2b44409d9f54_create_get_recommendable_offers_ordered_by_digital_offers.py
@@ -1,0 +1,88 @@
+"""create_get_recommendable_offers_ordered_by_digital_offers
+Revision ID: 2b44409d9f54
+Revises: da973e646e06
+Create Date: 2020-04-02 11:47:27.703029
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2b44409d9f54'
+down_revision = 'da973e646e06'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE OR REPLACE FUNCTION get_recommendable_offers_ordered_by_digital_offers()
+        RETURNS TABLE (
+            criterion_score BIGINT,
+            id BIGINT,
+            "venueId" BIGINT,
+            type VARCHAR,
+            name VARCHAR,
+            url VARCHAR,
+            "isNational" BOOLEAN,
+            partitioned_offers BIGINT
+        ) AS $body$
+        BEGIN
+            RETURN QUERY
+            SELECT
+                (SELECT * FROM get_offer_score(offer.id)) AS criterion_score,
+                offer.id AS id,
+                offer."venueId" AS "venueId",
+                offer.type AS type,
+                offer.name AS name,
+                offer.url AS url,
+                offer."isNational" AS "isNational",
+                ROW_NUMBER() OVER (
+                    ORDER BY
+                        offer.url IS NOT NULL DESC,
+                        (EXISTS (SELECT 1 FROM stock WHERE stock."offerId" = offer.id AND stock."beginningDatetime" > '2020-04-25T00:00:00'::TIMESTAMP)) DESC,
+                        (
+                            SELECT COALESCE(SUM(criterion."scoreDelta"), 0) AS coalesce_1
+                            FROM criterion, offer_criterion
+                            WHERE criterion.id = offer_criterion."criterionId"
+                                AND offer_criterion."offerId" = offer.id
+                        ) DESC,
+                        RANDOM()
+                ) AS partitioned_offers
+            FROM offer
+            WHERE offer.id IN (
+                SELECT DISTINCT ON (offer.id) offer.id
+                FROM offer
+                JOIN venue ON offer."venueId" = venue.id
+                JOIN offerer ON offerer.id = venue."managingOffererId"
+                WHERE offer."isActive" = TRUE
+                    AND venue."validationToken" IS NULL
+                    AND (EXISTS (SELECT * FROM offer_has_at_least_one_active_mediation(offer.id)))
+                    AND (EXISTS (SELECT * FROM offer_has_at_least_one_bookable_stock(offer.id)))
+                    AND offerer."isActive" = TRUE
+                    AND offerer."validationToken" IS NULL
+                    AND offer.type != 'ThingType.ACTIVATION'
+                    AND offer.type != 'EventType.ACTIVATION'
+            )
+            ORDER BY ROW_NUMBER() OVER (
+                ORDER BY
+                    offer.url IS NOT NULL DESC,
+                    (EXISTS (SELECT 1 FROM stock WHERE stock."offerId" = offer.id AND stock."beginningDatetime" > '2020-04-25T00:00:00'::TIMESTAMP)) DESC,
+                    (
+                        SELECT COALESCE(SUM(criterion."scoreDelta"), 0) AS coalesce_1
+                        FROM criterion, offer_criterion
+                        WHERE criterion.id = offer_criterion."criterionId"
+                            AND offer_criterion."offerId" = offer.id
+                    ) DESC,
+                    RANDOM()
+            );
+        END
+        $body$
+        LANGUAGE plpgsql;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DROP FUNCTION get_recommendable_offers_ordered_by_digital_offers;
+    """)

--- a/alembic/versions/747f6c0639b0_create_discovery_view_v3.py
+++ b/alembic/versions/747f6c0639b0_create_discovery_view_v3.py
@@ -1,0 +1,41 @@
+"""create_discovery_view_v3
+Revision ID: 747f6c0639b0
+Revises: 2b44409d9f54
+Create Date: 2020-04-02 11:57:27.703029
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '747f6c0639b0'
+down_revision = '2b44409d9f54'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE MATERIALIZED VIEW IF NOT EXISTS discovery_view_v3 AS
+            SELECT
+                ROW_NUMBER() OVER ()                AS "offerDiscoveryOrder",
+                recommendable_offers.id             AS id,
+                recommendable_offers."venueId"      AS "venueId",
+                recommendable_offers.type           AS type,
+                recommendable_offers.name           AS name,
+                recommendable_offers.url            AS url,
+                recommendable_offers."isNational"   AS "isNational",
+                offer_mediation.id                  AS "mediationId"
+            FROM (SELECT * FROM get_recommendable_offers()) AS recommendable_offers
+            LEFT OUTER JOIN mediation AS offer_mediation ON recommendable_offers.id = offer_mediation."offerId"
+                AND offer_mediation."isActive"
+            ORDER BY recommendable_offers.partitioned_offers;
+
+            CREATE UNIQUE INDEX ON discovery_view_v3 ("offerDiscoveryOrder");
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DROP MATERIALIZED VIEW discovery_view_v3;
+    """)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,13 +3,14 @@ from models.api_errors import ApiErrors
 from models.api_key import ApiKey
 from models.bank_information import BankInformation
 from models.beneficiary_import import BeneficiaryImport
-from models.beneficiary_import_status import BeneficiaryImportStatus
-from models.beneficiary_import_status import ImportStatus
+from models.beneficiary_import_status import BeneficiaryImportStatus, \
+    ImportStatus
 from models.booking import Booking
 from models.criterion import Criterion
 from models.deactivable_mixin import DeactivableMixin
 from models.deposit import Deposit
 from models.discovery_view import DiscoveryView
+from models.discovery_view_v3 import DiscoveryViewV3
 from models.email import Email
 from models.extra_data_mixin import ExtraDataMixin
 from models.favorite import Favorite
@@ -22,28 +23,26 @@ from models.mediation import Mediation
 from models.needs_validation_mixin import NeedsValidationMixin
 from models.offer import Offer
 from models.offer_criterion import OfferCriterion
-from models.offer_type import ThingType, EventType
+from models.offer_type import EventType, ThingType
 from models.offerer import Offerer
 from models.payment import Payment
 from models.payment_message import PaymentMessage
 from models.payment_status import PaymentStatus
 from models.pc_object import PcObject
-from models.product import BookFormat
-from models.product import Product
+from models.product import BookFormat, Product
 from models.providable_mixin import ProvidableMixin
 from models.provider import Provider
 from models.recommendation import Recommendation
 from models.stock import Stock
-from models.stock import Stock
 from models.user import User
-from models.user_offerer import RightsType
-from models.user_offerer import UserOfferer
+from models.user_offerer import RightsType, UserOfferer
 from models.user_session import UserSession
 from models.venue import Venue
 from models.venue_provider import VenueProvider
 from models.versioned_mixin import VersionedMixin
 from models.allocine_venue_provider import AllocineVenueProvider
-from models.allocine_venue_provider_price_rule import AllocineVenueProviderPriceRule
+from models.allocine_venue_provider_price_rule import \
+    AllocineVenueProviderPriceRule
 from models.iris_france import IrisFrance
 
 __all__ = (
@@ -133,4 +132,5 @@ models = (
 
 materialized_views = (
     DiscoveryView,
+    DiscoveryViewV3,
 )

--- a/models/install.py
+++ b/models/install.py
@@ -28,7 +28,7 @@ def install_models():
 
 def install_materialized_views():
     for materialized_view in models.materialized_views:
-        materialized_view.create(session=db.session)
+        materialized_view(session=db.session).create()
 
 
 def install_features():

--- a/repository/offer_queries.py
+++ b/repository/offer_queries.py
@@ -18,7 +18,7 @@ from models import EventType, \
     Stock, \
     ThingType, \
     Venue, \
-    Product, Favorite, Booking, DiscoveryView, User
+    Product, Favorite, Booking, DiscoveryView, DiscoveryViewV3, User
 from models.db import Model, db
 from models.feature import FeatureToggle
 from repository import feature_queries
@@ -550,17 +550,17 @@ def get_offers_for_recommendation_v3(user: User, user_iris_id: Optional[int] = N
 
     booked_offers_ids = get_only_offer_ids_from_bookings(user)
 
-    discovery_view_query = DiscoveryView.query \
-        .filter(DiscoveryView.id.notin_(favorite_offers_ids)) \
-        .filter(DiscoveryView.id.notin_(seen_recommendation_ids)) \
-        .filter(DiscoveryView.id.notin_(booked_offers_ids))
+    discovery_view_query = DiscoveryViewV3.query \
+        .filter(DiscoveryViewV3.id.notin_(favorite_offers_ids)) \
+        .filter(DiscoveryViewV3.id.notin_(seen_recommendation_ids)) \
+        .filter(DiscoveryViewV3.id.notin_(booked_offers_ids))
 
     if user_is_geolocated:
         venue_ids = find_venues_located_near_iris(user_iris_id)
         discovery_view_query = keep_only_offers_from_venues_located_near_to_user_or_national(discovery_view_query,
                                                                                              venue_ids)
 
-    discovery_view_query = discovery_view_query.order_by(DiscoveryView.offerDiscoveryOrder)
+    discovery_view_query = discovery_view_query.order_by(DiscoveryViewV3.offerDiscoveryOrder)
 
     if limit:
         discovery_view_query = discovery_view_query.limit(limit)
@@ -570,4 +570,4 @@ def get_offers_for_recommendation_v3(user: User, user_iris_id: Optional[int] = N
 
 def keep_only_offers_from_venues_located_near_to_user_or_national(query: BaseQuery,
                                                                   venue_ids: List[int] = []) -> BaseQuery:
-    return query.filter(or_(DiscoveryView.venueId.in_(venue_ids), DiscoveryView.isNational == True))
+    return query.filter(or_(DiscoveryViewV3.venueId.in_(venue_ids), DiscoveryViewV3.isNational == True))

--- a/sandboxes/scripts/creators/industrial/__init__.py
+++ b/sandboxes/scripts/creators/industrial/__init__.py
@@ -1,18 +1,20 @@
-from models import DiscoveryView
+from models import DiscoveryView, DiscoveryViewV3
 from sandboxes.scripts.creators.industrial.create_industrial_activation_offers import \
     create_industrial_activation_offers
 from sandboxes.scripts.creators.industrial.create_industrial_admin_users import *
 from sandboxes.scripts.creators.industrial.create_industrial_algolia_objects import \
     create_industrial_algolia_indexed_objects
 from sandboxes.scripts.creators.industrial.create_industrial_bookings import *
-from sandboxes.scripts.creators.industrial.create_industrial_criterion import create_industrial_criteria, \
-    associate_criterion_to_one_offer_with_mediation
+from sandboxes.scripts.creators.industrial.create_industrial_criterion import \
+    associate_criterion_to_one_offer_with_mediation, create_industrial_criteria
 from sandboxes.scripts.creators.industrial.create_industrial_deposits import *
 from sandboxes.scripts.creators.industrial.create_industrial_event_occurrences import *
 from sandboxes.scripts.creators.industrial.create_industrial_event_offers import *
 from sandboxes.scripts.creators.industrial.create_industrial_event_products import *
 from sandboxes.scripts.creators.industrial.create_industrial_event_stocks import *
-from sandboxes.scripts.creators.industrial.create_industrial_iris_venues import create_industrial_iris_venues
+from sandboxes.scripts.creators.industrial.create_industrial_iris import *
+from sandboxes.scripts.creators.industrial.create_industrial_iris_venues import \
+    create_industrial_iris_venues
 from sandboxes.scripts.creators.industrial.create_industrial_mediations import *
 from sandboxes.scripts.creators.industrial.create_industrial_offerers_with_pro_users import *
 from sandboxes.scripts.creators.industrial.create_industrial_payments import *
@@ -24,7 +26,6 @@ from sandboxes.scripts.creators.industrial.create_industrial_thing_products impo
 from sandboxes.scripts.creators.industrial.create_industrial_thing_stocks import *
 from sandboxes.scripts.creators.industrial.create_industrial_venues import *
 from sandboxes.scripts.creators.industrial.create_industrial_webapp_users import *
-from sandboxes.scripts.creators.industrial.create_industrial_iris import *
 
 
 def save_industrial_sandbox():
@@ -72,6 +73,8 @@ def save_industrial_sandbox():
     create_industrial_mediations(offers_by_name)
 
     DiscoveryView.refresh()
+    DiscoveryViewV3.refresh()
+
     recommendations_by_name = create_industrial_recommendations(
         offers_by_name,
         users_by_name
@@ -92,5 +95,5 @@ def save_industrial_sandbox():
     create_industrial_algolia_indexed_objects()
 
     create_industrial_iris(FILE_PATH)
-    
+
     create_industrial_iris_venues()

--- a/tests/recommendation_engine/recommendations_v3_test.py
+++ b/tests/recommendation_engine/recommendations_v3_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from models.discovery_view import DiscoveryView
+from models import DiscoveryView, DiscoveryViewV3
 from recommendations_engine.recommendations import create_recommendations_for_discovery_v3
 from repository import repository
 from tests.conftest import clean_database
@@ -33,7 +33,7 @@ class CreateRecommendationsForDiscoveryTest:
         iris_venue = create_iris_venue(iris, venue)
         repository.save(iris_venue)
 
-        DiscoveryView.refresh(concurrently=False)
+        DiscoveryViewV3.refresh(concurrently=False)
 
         # When
         recommendations = create_recommendations_for_discovery_v3(user=user, user_iris_id=iris.id,

--- a/tests/repository/get_offers_for_recommendation_v3_test.py
+++ b/tests/repository/get_offers_for_recommendation_v3_test.py
@@ -2,15 +2,21 @@ from datetime import datetime, timedelta
 
 from shapely.geometry import Polygon
 
-from models import DiscoveryView, ThingType, EventType
+from models import DiscoveryViewV3, EventType, ThingType
 from repository import repository
 from repository.offer_queries import get_offers_for_recommendation_v3
 from tests.conftest import clean_database
-from tests.model_creators.generic_creators import create_offerer, create_user, create_venue, create_mediation, \
-    create_iris, create_iris_venue, create_booking, create_criterion, create_favorite
-from tests.model_creators.specific_creators import create_product_with_thing_type, create_stock_from_offer, \
-    create_offer_with_thing_product, create_stock_with_thing_offer, create_stock_with_event_offer, \
-    create_offer_with_event_product
+from tests.model_creators.generic_creators import create_booking, \
+    create_criterion, \
+    create_favorite, create_iris, \
+    create_iris_venue, \
+    create_mediation, \
+    create_offerer, create_user, \
+    create_venue
+from tests.model_creators.specific_creators import \
+    create_offer_with_event_product, create_offer_with_thing_product, \
+    create_product_with_thing_type, create_stock_from_offer, \
+    create_stock_with_event_offer, create_stock_with_thing_offer
 from tests.test_utils import POLYGON_TEST
 
 
@@ -30,10 +36,9 @@ class GetOffersForRecommendationV3Test:
             mediation1 = create_mediation(stock.offer)
             mediation2 = create_mediation(stock_activation.offer)
 
-
             repository.save(user, stock, stock_activation, mediation1, mediation2)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -58,7 +63,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock_93, stock_activation_93)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -81,7 +86,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -90,7 +95,7 @@ class GetOffersForRecommendationV3Test:
             assert len(offers) == 1
 
         @clean_database
-        def test_should_return_offers_with_mediation_only(app):
+        def test_should_return_offers_with_mediation_only(self, app):
             # Given
             offerer = create_offerer()
             user = create_user()
@@ -100,9 +105,7 @@ class GetOffersForRecommendationV3Test:
             create_mediation(stock1.offer)
 
             repository.save(user, stock1, stock2)
-
-
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -131,7 +134,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock1, stock2, stock3)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -166,7 +169,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock1, stock2, stock3, stock4, stock5, stock6, user)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             def _first_four_offers_have_different_type_and_onlineness(offers):
                 return len(set([o.type + (o.url or '')
@@ -194,7 +197,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, booking1, booking2)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -222,7 +225,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock1, stock2)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -255,7 +258,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock1, stock2, stock3)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -277,7 +280,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -299,7 +302,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -321,7 +324,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -344,7 +347,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, stock)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -367,7 +370,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, booking)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -389,7 +392,7 @@ class GetOffersForRecommendationV3Test:
 
             repository.save(user, favorite)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             # When
             offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
@@ -420,7 +423,7 @@ class GetOffersForRecommendationV3Test:
                 iris_venue = create_iris_venue(venue_location_iris, venue)
                 repository.save(iris_venue)
 
-                DiscoveryView.refresh(concurrently=False)
+                DiscoveryViewV3.refresh(concurrently=False)
 
                 # When
                 offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
@@ -450,7 +453,7 @@ class GetOffersForRecommendationV3Test:
                 iris_venue = create_iris_venue(venue_location_iris, venue)
                 repository.save(iris_venue)
 
-                DiscoveryView.refresh(concurrently=False)
+                DiscoveryViewV3.refresh(concurrently=False)
 
                 # when
                 offers = get_offers_for_recommendation_v3(user=user, user_iris_id=user_location_iris.id,
@@ -479,7 +482,7 @@ class GetOffersForRecommendationV3Test:
 
                 repository.save(user, stock, stock_on_digital_offer, stock_on_national_offer)
 
-                DiscoveryView.refresh(concurrently=False)
+                DiscoveryViewV3.refresh(concurrently=False)
 
                 # when
                 offers = get_offers_for_recommendation_v3(user=user, user_iris_id=None, user_is_geolocated=True)
@@ -503,12 +506,10 @@ class GetOffersForRecommendationV3Test:
 
                 repository.save(user, stock)
 
-                DiscoveryView.refresh(concurrently=False)
+                DiscoveryViewV3.refresh(concurrently=False)
 
                 # when
                 offers = get_offers_for_recommendation_v3(user=user, user_is_geolocated=False)
 
                 # then
                 assert len(offers) == 1
-
-

--- a/tests/routes/put_recommendations_v3_test.py
+++ b/tests/routes/put_recommendations_v3_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from shapely.geometry import Polygon
 
-from models import Feature, DiscoveryView, Mediation, ThingType
+from models import Feature, DiscoveryViewV3, Mediation, ThingType
 from models.feature import FeatureToggle
 from repository import repository
 from tests.conftest import TestClient, clean_database
@@ -72,7 +72,7 @@ class Put:
             feature.isActive = True
 
             repository.save(user, stock, mediation, feature, iris_venue)
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             reads = [
                 {"id": humanize(1), "dateRead": "2018-12-17T15:59:11.689000Z"},
@@ -113,7 +113,7 @@ class Put:
 
             repository.save(user, stock1)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             auth_request = TestClient(app.test_client()).with_auth(user.email)
 
@@ -160,7 +160,7 @@ class Put:
             feature.isActive = True
 
             repository.save(user, stock, stock_of_digital_offer, mediation, mediation_of_digital_offer, feature)
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             auth_request = TestClient(app.test_client()).with_auth(user.email)
 
@@ -204,7 +204,7 @@ class Put:
             iris_venue = create_iris_venue(iris, venue)
             repository.save(iris_venue)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
 
             upsert_tuto_mediations()
 
@@ -312,7 +312,7 @@ class Put:
             iris_venue = create_iris_venue(iris, venue)
             repository.save(iris_venue)
 
-            DiscoveryView.refresh(concurrently=False)
+            DiscoveryViewV3.refresh(concurrently=False)
             auth_request = TestClient(app.test_client()).with_auth(user.email)
 
             # when


### PR DESCRIPTION
L'idée est de mettre à jour la fonction SQL existante `get_recommendable_offers` avec le nouvel `ORDER BY`.
- Pour récupérer ce bout de SQL, j'ai tout simplement affiché le requête de reco v1 et fait un copié/collé (cf `_order_by_digital_offers()`);
- J'ai aussi supprimé le `PARTITION BY` ;
- J'ai repris les tests de la v1 en adaptant ;
- Il n'y a pas de feature flipping, on refera une MEP en enlevant cette fonction ;
- J'ai skipé certains tests pour les remettre par la suite ;
- J'ai ajouté une vue matérialisée pour la v3 ;
- J'ai refacto DiscoveryView pour être un peu plus POO.

Pour changer la date, changer la variable d'env END_OF_QUARANTINE_DATE puis :
````python
DiscoveryView(db.session)._create_function_get_recommendable_offers_ordered_by_digital_offers()
db.session.commit()
```