### PR TITLE
(PC-3240) : Modification of query in product_queries and tests

### DIFF
--- a/repository/product_queries.py
+++ b/repository/product_queries.py
@@ -23,6 +23,9 @@ def delete_unwanted_existing_product(isbn: str):
         .count() > 0
     product = find_active_book_product_by_isbn(isbn)
 
+    if not product:
+        return
+
     if product_has_at_least_one_booking:
         offers = get_offers_by_product_id(product.id)
         product.isGcuCompatible = False
@@ -31,20 +34,19 @@ def delete_unwanted_existing_product(isbn: str):
         raise ProductWithBookingsException
 
     objects_to_delete = []
-    if product:
-        objects_to_delete.append(product)
-        offers = get_offers_by_product_id(product.id)
-        offer_ids = [offer.id for offer in offers]
-        objects_to_delete = objects_to_delete + offers
-        stocks = get_stocks_for_offers(offer_ids)
-        objects_to_delete = objects_to_delete + stocks
-        recommendations = get_recommendations_for_offers(offer_ids)
-        mediations = get_mediations_for_offers(offer_ids)
-        objects_to_delete = objects_to_delete + mediations
-        favorites = get_favorites_for_offers(offer_ids)
-        objects_to_delete = objects_to_delete + favorites
-        objects_to_delete = objects_to_delete + recommendations
-        repository.delete(*objects_to_delete)
+    objects_to_delete.append(product)
+    offers = get_offers_by_product_id(product.id)
+    offer_ids = [offer.id for offer in offers]
+    objects_to_delete = objects_to_delete + offers
+    stocks = get_stocks_for_offers(offer_ids)
+    objects_to_delete = objects_to_delete + stocks
+    recommendations = get_recommendations_for_offers(offer_ids)
+    mediations = get_mediations_for_offers(offer_ids)
+    objects_to_delete = objects_to_delete + mediations
+    favorites = get_favorites_for_offers(offer_ids)
+    objects_to_delete = objects_to_delete + favorites
+    objects_to_delete = objects_to_delete + recommendations
+    repository.delete(*objects_to_delete)
 
 
 def find_by_id(product_id: int) -> Product:

--- a/tests/repository/product_queries_test.py
+++ b/tests/repository/product_queries_test.py
@@ -41,6 +41,23 @@ class DeleteUnwantedExistingProductTest:
         assert Product.query.count() == 1
 
     @clean_database
+    def test_should_delete_nothing_when_product_not_found(self, app):
+        # Given
+        isbn = '1111111111111'
+        product = create_product_with_thing_type(
+            id_at_providers=isbn,
+            is_gcu_compatible=False,
+            thing_type=ThingType.LIVRE_EDITION,
+        )
+        repository.save(product)
+
+        # When
+        delete_unwanted_existing_product(isbn)
+
+        # Then
+        assert Product.query.count() == 1
+
+    @clean_database
     def test_should_delete_product_when_it_has_offer_and_stock_but_not_booked(self, app):
         # Given
         isbn = '1111111111111'


### PR DESCRIPTION
Correction d'une erreur sur le cron titelive_things qui remontait des erreurs dues à des products Null non catché suite à l'ajout d'un filtre dans une query