### PR TITLE
(PC-2985): Gathering last import date by procedure

### DIFF
--- a/repository/beneficiary_import_queries.py
+++ b/repository/beneficiary_import_queries.py
@@ -20,7 +20,7 @@ def is_already_imported(application_id: int) -> bool:
 
 def save_beneficiary_import_with_status(status: ImportStatus,
                                         demarche_simplifiee_application_id: int,
-                                        demarche_simplifiee_procedure_id: Optional[int],
+                                        demarche_simplifiee_procedure_id: int,
                                         user: User = None,
                                         detail: str = None):
     existing_beneficiary_import = BeneficiaryImport.query \

--- a/repository/beneficiary_import_queries.py
+++ b/repository/beneficiary_import_queries.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from sqlalchemy import asc
 

--- a/repository/user_queries.py
+++ b/repository/user_queries.py
@@ -1,33 +1,42 @@
-from datetime import datetime, MINYEAR
+from datetime import MINYEAR, datetime
 from typing import List
 
-from sqlalchemy import func, Column
+from sqlalchemy import Column, func
+from sqlalchemy.orm import Query
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.functions import Function
 
-from models import ImportStatus, BeneficiaryImport, BeneficiaryImportStatus, Booking, Stock, Offer, ThingType, EventType, User
-from models import UserOfferer, Offerer, RightsType
+from models import BeneficiaryImport, BeneficiaryImportStatus, Booking, \
+    EventType, ImportStatus, Offer, Offerer, RightsType, Stock, \
+    ThingType, User, UserOfferer
 from models.db import db
 from models.user import WalletBalance
 
 
 def count_all_activated_users() -> int:
-    return User.query.filter_by(canBookFreeOffers=True).count()
+    return User.query \
+        .filter_by(canBookFreeOffers=True) \
+        .count()
 
 
-def count_all_activated_users_by_departement(department_code) -> int:
-    return User.query.filter_by(canBookFreeOffers=True).filter_by(departementCode=department_code).count()
+def count_all_activated_users_by_departement(department_code: str) -> int:
+    return User.query \
+        .filter_by(canBookFreeOffers=True) \
+        .filter_by(departementCode=department_code) \
+        .count()
 
 
 def count_users_by_email(email: str) -> int:
-    return User.query.filter_by(email=email).count()
+    return User.query \
+        .filter_by(email=email) \
+        .count()
 
 
-def _query_user_having_booked():
-    return User.query.join(Booking)\
-        .join(Stock)\
-        .join(Offer)\
-        .filter(Offer.type != str(ThingType.ACTIVATION))\
+def _query_user_having_booked() -> Query:
+    return User.query.join(Booking) \
+        .join(Stock) \
+        .join(Offer) \
+        .filter(Offer.type != str(ThingType.ACTIVATION)) \
         .filter(Offer.type != str(EventType.ACTIVATION)) \
         .distinct(User.id)
 
@@ -50,7 +59,7 @@ def find_user_by_email(email: str) -> User:
 
 def find_by_civility(first_name: str, last_name: str, birth_date: datetime) -> List[User]:
     civility_predicate = (_matching(User.firstName, first_name)) & (_matching(User.lastName, last_name)) & (
-            User.dateOfBirth == birth_date)
+        User.dateOfBirth == birth_date)
 
     return User.query \
         .filter(civility_predicate) \
@@ -58,20 +67,28 @@ def find_by_civility(first_name: str, last_name: str, birth_date: datetime) -> L
 
 
 def find_by_validation_token(token: str) -> User:
-    return User.query.filter_by(validationToken=token).first()
+    return User.query \
+        .filter_by(validationToken=token) \
+        .first()
 
 
 def find_user_by_reset_password_token(token: str) -> User:
-    return User.query.filter_by(resetPasswordToken=token).first()
+    return User.query \
+        .filter_by(resetPasswordToken=token) \
+        .first()
 
 
 def find_all_emails_of_user_offerers_admins(offerer_id: int) -> List[str]:
     filter_validated_user_offerers_with_admin_rights = (UserOfferer.rights == RightsType.admin) & (
-            UserOfferer.validationToken == None)
-    return [result.email for result in
-            User.query.join(UserOfferer).filter(filter_validated_user_offerers_with_admin_rights).join(
-                Offerer).filter_by(
-                id=offerer_id).all()]
+        UserOfferer.validationToken == None)
+    admins = User.query \
+        .join(UserOfferer) \
+        .filter(filter_validated_user_offerers_with_admin_rights) \
+        .join(Offerer) \
+        .filter_by(id=offerer_id) \
+        .all()
+
+    return [result.email for result in admins]
 
 
 def get_all_users_wallet_balances() -> List[WalletBalance]:
@@ -88,52 +105,41 @@ def get_all_users_wallet_balances() -> List[WalletBalance]:
     return list(map(instantiate_result_set, wallet_balances))
 
 
-def filter_users_with_at_least_one_validated_offerer_validated_user_offerer(query):
-    query = query.join(UserOfferer) \
+def filter_users_with_at_least_one_validated_offerer_validated_user_offerer(query: Query) -> Query:
+    return query \
+        .join(UserOfferer) \
         .join(Offerer) \
         .filter(
-        (Offerer.validationToken == None) & \
-        (UserOfferer.validationToken == None)
-    )
-    return query
+            (Offerer.validationToken == None) & \
+            (UserOfferer.validationToken == None)
+        )
 
 
-def filter_users_with_at_least_one_validated_offerer_not_validated_user_offerer(query):
-    query = query.join(UserOfferer) \
+def filter_users_with_at_least_one_validated_offerer_not_validated_user_offerer(query: Query) -> Query:
+    return query \
+        .join(UserOfferer) \
         .join(Offerer) \
         .filter(
-        (Offerer.validationToken == None) & \
-        (UserOfferer.validationToken != None)
-    )
-    return query
+            (Offerer.validationToken == None) & \
+            (UserOfferer.validationToken != None)
+        )
 
 
-def filter_users_with_at_least_one_not_activated_offerer_not_validated_user_offerer(query):
-    query = query.join(UserOfferer) \
+def filter_users_with_at_least_one_not_validated_offerer_validated_user_offerer(query: Query) -> Query:
+    return query \
+        .join(UserOfferer) \
         .join(Offerer) \
         .filter(
-        (Offerer.validationToken != None) & \
-        (UserOfferer.validationToken != None)
-    )
-    return query
+            (Offerer.validationToken != None) & \
+            (UserOfferer.validationToken == None)
+        )
 
 
-def filter_users_with_at_least_one_not_validated_offerer_validated_user_offerer(query):
-    query = query.join(UserOfferer) \
-        .join(Offerer) \
-        .filter(
-        (Offerer.validationToken != None) & \
-        (UserOfferer.validationToken == None)
-    )
-    return query
-
-
-def keep_only_webapp_users(query):
-    query = query.filter(
+def keep_only_webapp_users(query: Query) -> Query:
+    return query.filter(
         (~User.UserOfferers.any()) & \
         (User.isAdmin == False)
     )
-    return query
 
 
 def find_most_recent_beneficiary_creation_date_by_procedure_id(demarche_simplifiee_procedure_id: int) -> datetime:
@@ -162,5 +168,5 @@ def _sanitized_string(value: str) -> Function:
     return sanitized
 
 
-def find_user_by_id(user_id: id) -> User:
+def find_user_by_id(user_id: int) -> User:
     return User.query.get(user_id)

--- a/repository/user_queries.py
+++ b/repository/user_queries.py
@@ -142,7 +142,7 @@ def keep_only_webapp_users(query: Query) -> Query:
     )
 
 
-def find_most_recent_beneficiary_creation_date_by_procedure_id(demarche_simplifiee_procedure_id: int) -> datetime:
+def find_most_recent_beneficiary_creation_date_for_procedure_id(demarche_simplifiee_procedure_id: int) -> datetime:
     most_recent_creation = BeneficiaryImportStatus.query \
         .join(BeneficiaryImport) \
         .filter(BeneficiaryImport.demarcheSimplifieeProcedureId == demarche_simplifiee_procedure_id) \

--- a/repository/user_queries.py
+++ b/repository/user_queries.py
@@ -5,7 +5,7 @@ from sqlalchemy import func, Column
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.functions import Function
 
-from models import ImportStatus, BeneficiaryImportStatus, Booking, Stock, Offer, ThingType, EventType, User
+from models import ImportStatus, BeneficiaryImport, BeneficiaryImportStatus, Booking, Stock, Offer, ThingType, EventType, User
 from models import UserOfferer, Offerer, RightsType
 from models.db import db
 from models.user import WalletBalance
@@ -136,8 +136,10 @@ def keep_only_webapp_users(query):
     return query
 
 
-def find_most_recent_beneficiary_creation_date() -> datetime:
+def find_most_recent_beneficiary_creation_date_by_procedure_id(demarche_simplifiee_procedure_id: int) -> datetime:
     most_recent_creation = BeneficiaryImportStatus.query \
+        .join(BeneficiaryImport) \
+        .filter(BeneficiaryImport.demarcheSimplifieeProcedureId == demarche_simplifiee_procedure_id) \
         .filter(BeneficiaryImportStatus.status == ImportStatus.CREATED) \
         .order_by(BeneficiaryImportStatus.date.desc()) \
         .first()

--- a/scheduled_tasks/clock.py
+++ b/scheduled_tasks/clock.py
@@ -12,7 +12,8 @@ from models.db import db
 from models.feature import FeatureToggle
 from repository.feature_queries import feature_write_dashboard_enabled
 from repository.provider_queries import get_provider_by_local_class
-from repository.user_queries import find_most_recent_beneficiary_creation_date_by_procedure_id
+from repository.user_queries import \
+    find_most_recent_beneficiary_creation_date_by_procedure_id
 from scheduled_tasks.decorators import cron_context, cron_require_feature, \
     log_cron
 from scripts.beneficiary import old_remote_import, remote_import
@@ -23,6 +24,7 @@ from utils.mailing import MAILJET_API_KEY, MAILJET_API_SECRET
 
 DEMARCHES_SIMPLIFIEES_OLD_ENROLLMENT_PROCEDURE_ID = os.environ.get('DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID', None)
 DEMARCHES_SIMPLIFIEES_NEW_ENROLLMENT_PROCEDURE_ID = os.environ.get('DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2', None)
+
 
 @log_cron
 @cron_context

--- a/scheduled_tasks/clock.py
+++ b/scheduled_tasks/clock.py
@@ -12,8 +12,12 @@ from models.db import db
 from models.feature import FeatureToggle
 from repository.feature_queries import feature_write_dashboard_enabled
 from repository.provider_queries import get_provider_by_local_class
+<<<<<<< Updated upstream
 from repository.user_queries import \
     find_most_recent_beneficiary_creation_date_by_procedure_id
+=======
+from repository.user_queries import find_most_recent_beneficiary_creation_date_for_procedure_id
+>>>>>>> Stashed changes
 from scheduled_tasks.decorators import cron_context, cron_require_feature, \
     log_cron
 from scripts.beneficiary import old_remote_import, remote_import
@@ -62,7 +66,7 @@ def pc_retrieve_bank_information(app):
 @cron_require_feature(FeatureToggle.BENEFICIARIES_IMPORT)
 def pc_old_remote_import_beneficiaries(app):
     procedure_id = int(DEMARCHES_SIMPLIFIEES_OLD_ENROLLMENT_PROCEDURE_ID)
-    import_from_date = find_most_recent_beneficiary_creation_date_by_procedure_id(procedure_id)
+    import_from_date = find_most_recent_beneficiary_creation_date_for_procedure_id(procedure_id)
     old_remote_import.run(import_from_date)
 
 
@@ -70,7 +74,7 @@ def pc_old_remote_import_beneficiaries(app):
 @cron_context
 def pc_remote_import_beneficiaries(app):
     procedure_id = int(DEMARCHES_SIMPLIFIEES_NEW_ENROLLMENT_PROCEDURE_ID)
-    import_from_date = find_most_recent_beneficiary_creation_date_by_procedure_id(procedure_id)
+    import_from_date = find_most_recent_beneficiary_creation_date_for_procedure_id(procedure_id)
     remote_import.run(import_from_date)
 
 

--- a/scheduled_tasks/clock.py
+++ b/scheduled_tasks/clock.py
@@ -15,7 +15,7 @@ from repository.provider_queries import get_provider_by_local_class
 from repository.user_queries import find_most_recent_beneficiary_creation_date_by_procedure_id
 from scheduled_tasks.decorators import cron_context, cron_require_feature, \
     log_cron
-from scripts.beneficiary import remote_import
+from scripts.beneficiary import old_remote_import
 from scripts.dashboard.write_dashboard import write_dashboard
 from scripts.update_booking_used import \
     update_booking_used_after_stock_occurrence
@@ -60,7 +60,7 @@ def pc_retrieve_bank_information(app):
 def pc_remote_import_beneficiaries(app):
     procedure_id = int(DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID)
     import_from_date = find_most_recent_beneficiary_creation_date_by_procedure_id(procedure_id)
-    remote_import.run(import_from_date)
+    old_remote_import.run(import_from_date)
 
 
 @log_cron

--- a/scheduled_tasks/clock.py
+++ b/scheduled_tasks/clock.py
@@ -12,7 +12,7 @@ from models.db import db
 from models.feature import FeatureToggle
 from repository.feature_queries import feature_write_dashboard_enabled
 from repository.provider_queries import get_provider_by_local_class
-from repository.user_queries import find_most_recent_beneficiary_creation_date
+from repository.user_queries import find_most_recent_beneficiary_creation_date_by_procedure_id
 from scheduled_tasks.decorators import cron_context, cron_require_feature, \
     log_cron
 from scripts.beneficiary import remote_import
@@ -21,6 +21,7 @@ from scripts.update_booking_used import \
     update_booking_used_after_stock_occurrence
 from utils.mailing import MAILJET_API_KEY, MAILJET_API_SECRET
 
+DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID = os.environ.get('DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID', None)
 
 @log_cron
 @cron_context
@@ -57,7 +58,8 @@ def pc_retrieve_bank_information(app):
 @cron_context
 @cron_require_feature(FeatureToggle.BENEFICIARIES_IMPORT)
 def pc_remote_import_beneficiaries(app):
-    import_from_date = find_most_recent_beneficiary_creation_date()
+    procedure_id = int(DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID)
+    import_from_date = find_most_recent_beneficiary_creation_date_by_procedure_id(procedure_id)
     remote_import.run(import_from_date)
 
 

--- a/scripts/beneficiary/old_remote_import.py
+++ b/scripts/beneficiary/old_remote_import.py
@@ -1,6 +1,7 @@
 import os
 import re
 from datetime import datetime
+from pprint import pprint
 from typing import Callable, Dict, List, Set
 
 from connectors.api_demarches_simplifiees import get_application_details

--- a/scripts/beneficiary/old_remote_import.py
+++ b/scripts/beneficiary/old_remote_import.py
@@ -124,7 +124,7 @@ def _process_creation(error_messages: List[str], information: Dict, new_benefici
         error_messages.append(str(api_errors))
     else:
         logger.info(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application "
-                       f"{information['application_id']}")
+                    f"{information['application_id']}")
         save_beneficiary_import_with_status(
             ImportStatus.CREATED,
             information['application_id'],

--- a/scripts/beneficiary/remote_import.py
+++ b/scripts/beneficiary/remote_import.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Set
 
 from connectors.api_demarches_simplifiees import get_application_details
 from domain.demarches_simplifiees import \
-    get_all_application_ids_for_beneficiary_import
+    get_all_application_ids_for_demarche_simplifiee
 from domain.user_activation import create_beneficiary_from_application
 from domain.user_emails import send_activation_email
 from models import ApiErrors, ImportStatus, User
@@ -23,21 +23,21 @@ VALIDATED_APPLICATION = 'closed'
 
 def run(
         process_applications_updated_after: datetime,
-        get_all_applications_ids: Callable[..., List[int]] = get_all_application_ids_for_beneficiary_import,
+        get_all_applications_ids: Callable[..., List[int]] = get_all_application_ids_for_demarche_simplifiee,
         get_applications_ids_to_retry: Callable[..., List[int]] = find_applications_ids_to_retry,
         get_details: Callable[..., Dict] = get_application_details,
         already_imported: Callable[..., bool] = is_already_imported,
         already_existing_user: Callable[..., User] = find_user_by_email
 ) -> None:
     procedure_id = int(os.environ.get('DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2', None))
-    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Start import from Démarches Simplifiées for procedure = {procedure_id}')
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Start import from Démarches Simplifiées for procedure = {procedure_id} - Procedure {procedure_id}')
     error_messages = []
     new_beneficiaries = []
     applications_ids = get_all_applications_ids(procedure_id, TOKEN, process_applications_updated_after)
     retry_ids = get_applications_ids_to_retry()
 
-    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(applications_ids)} new applications to process')
-    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(retry_ids)} previous applications to retry')
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(applications_ids)} new applications to process - Procedure {procedure_id}')
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(retry_ids)} previous applications to retry - Procedure {procedure_id}')
 
     for application_id in (retry_ids + applications_ids):
         details = get_details(application_id, procedure_id, TOKEN)
@@ -60,7 +60,7 @@ def run(
                 procedure_id=procedure_id
             )
 
-    logger.info('[BATCH][REMOTE IMPORT BENEFICIARIES] End import from Démarches Simplifiées')
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] End import from Démarches Simplifiées - Procedure {procedure_id}')
 
 
 def process_beneficiary_application(
@@ -119,11 +119,11 @@ def _process_creation(error_messages: List[str], information: Dict, new_benefici
         repository.save(new_beneficiary)
     except ApiErrors as api_errors:
         logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Could not save application "
-                       f"{information['application_id']}, because of error: {str(api_errors)}")
+                       f"{information['application_id']}, because of error: {str(api_errors)} - Procedure {procedure_id}")
         error_messages.append(str(api_errors))
     else:
         logger.info(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application "
-                    f"{information['application_id']}")
+                    f"{information['application_id']} - Procedure {procedure_id}")
         save_beneficiary_import_with_status(
             ImportStatus.CREATED,
             information['application_id'],
@@ -133,13 +133,13 @@ def _process_creation(error_messages: List[str], information: Dict, new_benefici
         try:
             send_activation_email(new_beneficiary, send_raw_email)
         except MailServiceException as mail_service_exception:
-            logger.error(f"Email send_activation_email failure for application {information['application_id']}", mail_service_exception)
+            logger.error(f"Email send_activation_email failure for application {information['application_id']} - Procedure {procedure_id}", mail_service_exception)
 
 
 def _process_duplication(duplicate_users: List[User], error_messages: List[str], information: Dict, procedure_id: int) -> None:
     number_of_beneficiaries = len(duplicate_users)
     duplicate_ids = ", ".join([str(u.id) for u in duplicate_users])
-    message = f"{number_of_beneficiaries} utilisateur(s) en doublon {duplicate_ids} pour le dossier {information['application_id']}"
+    message = f"{number_of_beneficiaries} utilisateur(s) en doublon {duplicate_ids} pour le dossier {information['application_id']} - Procedure {procedure_id}"
     logger.warning(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Duplicate beneficiaries found : {message}')
     error_messages.append(message)
     save_beneficiary_import_with_status(ImportStatus.DUPLICATE, information['application_id'], procedure_id,
@@ -149,11 +149,11 @@ def _process_duplication(duplicate_users: List[User], error_messages: List[str],
 def _process_rejection(information: Dict, procedure_id: int) -> None:
     save_beneficiary_import_with_status(ImportStatus.REJECTED, information['application_id'], procedure_id,
                                         detail='Compte existant avec cet email')
-    logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Rejected application {information['application_id']} because of already existing email")
+    logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Rejected application {information['application_id']} because of already existing email - Procedure {procedure_id}")
 
 
 def _process_error(error_messages: List[str], application_id: int, procedure_id: int) -> None:
-    error = f"Le dossier {application_id} contient des erreurs et a été ignoré"
+    error = f"Le dossier {application_id} contient des erreurs et a été ignoré - Procedure {procedure_id}"
     logger.error(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {error}')
     error_messages.append(error)
     save_beneficiary_import_with_status(ImportStatus.ERROR, application_id, procedure_id, detail=error)

--- a/scripts/beneficiary/remote_import.py
+++ b/scripts/beneficiary/remote_import.py
@@ -1,0 +1,172 @@
+import os
+import re
+from datetime import datetime
+from pprint import pprint
+from typing import Callable, Dict, List, Set
+
+from connectors.api_demarches_simplifiees import get_application_details
+from domain.demarches_simplifiees import \
+    get_all_application_ids_for_beneficiary_import
+from domain.user_activation import create_beneficiary_from_application
+from domain.user_emails import send_activation_email
+from models import ApiErrors, ImportStatus, User
+from repository import repository
+from repository.beneficiary_import_queries import \
+    find_applications_ids_to_retry, is_already_imported, \
+    save_beneficiary_import_with_status
+from repository.user_queries import find_by_civility, find_user_by_email
+from utils.logger import logger
+from utils.mailing import MailServiceException, send_raw_email
+
+TOKEN = os.environ.get('DEMARCHES_SIMPLIFIEES_TOKEN', None)
+VALIDATED_APPLICATION = 'closed'
+
+
+def run(
+        process_applications_updated_after: datetime,
+        get_all_applications_ids: Callable[..., List[int]] = get_all_application_ids_for_beneficiary_import,
+        get_applications_ids_to_retry: Callable[..., List[int]] = find_applications_ids_to_retry,
+        get_details: Callable[..., Dict] = get_application_details,
+        already_imported: Callable[..., bool] = is_already_imported,
+        already_existing_user: Callable[..., User] = find_user_by_email
+) -> None:
+    procedure_id = int(os.environ.get('DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2', None))
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Start import from Démarches Simplifiées for procedure = {procedure_id}')
+    error_messages = []
+    new_beneficiaries = []
+    applications_ids = get_all_applications_ids(procedure_id, TOKEN, process_applications_updated_after)
+    retry_ids = get_applications_ids_to_retry()
+
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(applications_ids)} new applications to process')
+    logger.info(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {len(retry_ids)} previous applications to retry')
+
+    for application_id in (retry_ids + applications_ids):
+        details = get_details(application_id, procedure_id, TOKEN)
+        try:
+            information = parse_beneficiary_information(details)
+        except Exception:
+            _process_error(error_messages, application_id)
+            continue
+
+        if already_existing_user(information['email']):
+            _process_rejection(information)
+            continue
+
+        if not already_imported(information['application_id']):
+            process_beneficiary_application(
+                information=information,
+                error_messages=error_messages,
+                new_beneficiaries=new_beneficiaries,
+                retry_ids=retry_ids,
+                procedure_id=procedure_id
+            )
+
+    logger.info('[BATCH][REMOTE IMPORT BENEFICIARIES] End import from Démarches Simplifiées')
+
+
+def process_beneficiary_application(
+        information: Dict,
+        error_messages: List[str],
+        new_beneficiaries: List[User],
+        retry_ids: List[int],
+        procedure_id: int,
+        find_duplicate_users: Callable[..., List[User]] = find_by_civility
+) -> None:
+    duplicate_users = find_duplicate_users(
+        information['first_name'],
+        information['last_name'],
+        information['birth_date']
+    )
+
+    if not duplicate_users or information['application_id'] in retry_ids:
+        _process_creation(error_messages, information, new_beneficiaries, procedure_id)
+    else:
+        _process_duplication(duplicate_users, error_messages, information)
+
+
+def parse_beneficiary_information(application_detail: Dict) -> Dict:
+    dossier = application_detail['dossier']
+
+    information = {
+        'last_name': dossier['individual']['nom'],
+        'first_name': dossier['individual']['prenom'],
+        'civility': dossier['individual']['civilite'],
+        'email': dossier['email'],
+        'application_id': dossier['id']
+    }
+
+    for field in dossier['champs']:
+        label = field['type_de_champ']['libelle']
+        value = field['value']
+
+        if 'Veuillez indiquer votre département' in label:
+            information['department'] = re.search('^[0-9]{2,3}|[2BbAa]{2}', value).group(0)
+        if label == 'Quelle est votre date de naissance':
+            information['birth_date'] = datetime.strptime(value, '%Y-%m-%d')
+        if label == 'Quel est votre numéro de téléphone':
+            information['phone'] = value
+        if label == 'Quel est le code postal de votre commune de résidence ?':
+            space_free = str(value).strip().replace(' ', '')
+            information['postal_code'] = re.search('^[0-9]{5}', space_free).group(0)
+        if label == 'Veuillez indiquer votre statut':
+            information['activity'] = value
+
+    return information
+
+
+def _process_creation(error_messages: List[str], information: Dict, new_beneficiaries: List[User], procedure_id: int) -> None:
+    new_beneficiary = create_beneficiary_from_application(information)
+    try:
+        repository.save(new_beneficiary)
+    except ApiErrors as api_errors:
+        logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Could not save application "
+                       f"{information['application_id']}, because of error: {str(api_errors)}")
+        error_messages.append(str(api_errors))
+    else:
+        logger.info(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application "
+                       f"{information['application_id']}")
+        save_beneficiary_import_with_status(
+            ImportStatus.CREATED,
+            information['application_id'],
+            demarche_simplifiee_procedure_id=procedure_id,
+            user=new_beneficiary)
+        new_beneficiaries.append(new_beneficiary)
+        try:
+            send_activation_email(new_beneficiary, send_raw_email)
+        except MailServiceException as mail_service_exception:
+            logger.error(f"Email send_activation_email failure for application {information['application_id']}", mail_service_exception)
+
+
+def _process_duplication(duplicate_users: List[User], error_messages: List[str], information: Dict) -> None:
+    number_of_beneficiaries = len(duplicate_users)
+    duplicate_ids = ", ".join([str(u.id) for u in duplicate_users])
+    message = f"{number_of_beneficiaries} utilisateur(s) en doublon {duplicate_ids} pour le dossier {information['application_id']}"
+    logger.warning(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Duplicate beneficiaries found : {message}')
+    error_messages.append(message)
+    save_beneficiary_import_with_status(ImportStatus.DUPLICATE, information['application_id'], None,
+                                        detail=f"Utilisateur en doublon : {duplicate_ids}")
+
+
+def _process_rejection(information: Dict) -> None:
+    save_beneficiary_import_with_status(ImportStatus.REJECTED, information['application_id'], None,
+                                        detail='Compte existant avec cet email')
+    logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Rejected application {information['application_id']} because of already existing email")
+
+
+def _process_error(error_messages: List[str], application_id: int) -> None:
+    error = f"Le dossier {application_id} contient des erreurs et a été ignoré"
+    logger.error(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {error}')
+    error_messages.append(error)
+    save_beneficiary_import_with_status(ImportStatus.ERROR, application_id, None, detail=error)
+
+
+def _find_application_ids_to_process(applications: Dict, process_applications_updated_after: datetime) -> Set:
+    processable_applications = filter(lambda a: a['state'] == 'closed', applications['dossiers'])
+    recent_applications = filter(
+        lambda a: _parse_application_date(a) > process_applications_updated_after,
+        processable_applications)
+    return {application['id'] for application in recent_applications}
+
+
+def _parse_application_date(application: Dict) -> datetime:
+    return datetime.strptime(application['updated_at'], '%Y-%m-%dT%H:%M:%S.%fZ')

--- a/scripts/beneficiary/remote_import.py
+++ b/scripts/beneficiary/remote_import.py
@@ -1,7 +1,6 @@
 import os
 import re
 from datetime import datetime
-from pprint import pprint
 from typing import Callable, Dict, List, Set
 
 from connectors.api_demarches_simplifiees import get_application_details
@@ -124,7 +123,7 @@ def _process_creation(error_messages: List[str], information: Dict, new_benefici
         error_messages.append(str(api_errors))
     else:
         logger.info(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Successfully created user for application "
-                       f"{information['application_id']}")
+                    f"{information['application_id']}")
         save_beneficiary_import_with_status(
             ImportStatus.CREATED,
             information['application_id'],

--- a/scripts/beneficiary/remote_import.py
+++ b/scripts/beneficiary/remote_import.py
@@ -45,11 +45,11 @@ def run(
         try:
             information = parse_beneficiary_information(details)
         except Exception:
-            _process_error(error_messages, application_id)
+            _process_error(error_messages, application_id, procedure_id=procedure_id)
             continue
 
         if already_existing_user(information['email']):
-            _process_rejection(information)
+            _process_rejection(information, procedure_id=procedure_id)
             continue
 
         if not already_imported(information['application_id']):
@@ -81,7 +81,7 @@ def process_beneficiary_application(
     if not duplicate_users or information['application_id'] in retry_ids:
         _process_creation(error_messages, information, new_beneficiaries, procedure_id)
     else:
-        _process_duplication(duplicate_users, error_messages, information)
+        _process_duplication(duplicate_users, error_messages, information, procedure_id)
 
 
 def parse_beneficiary_information(application_detail: Dict) -> Dict:
@@ -137,27 +137,27 @@ def _process_creation(error_messages: List[str], information: Dict, new_benefici
             logger.error(f"Email send_activation_email failure for application {information['application_id']}", mail_service_exception)
 
 
-def _process_duplication(duplicate_users: List[User], error_messages: List[str], information: Dict) -> None:
+def _process_duplication(duplicate_users: List[User], error_messages: List[str], information: Dict, procedure_id: int) -> None:
     number_of_beneficiaries = len(duplicate_users)
     duplicate_ids = ", ".join([str(u.id) for u in duplicate_users])
     message = f"{number_of_beneficiaries} utilisateur(s) en doublon {duplicate_ids} pour le dossier {information['application_id']}"
     logger.warning(f'[BATCH][REMOTE IMPORT BENEFICIARIES] Duplicate beneficiaries found : {message}')
     error_messages.append(message)
-    save_beneficiary_import_with_status(ImportStatus.DUPLICATE, information['application_id'], None,
+    save_beneficiary_import_with_status(ImportStatus.DUPLICATE, information['application_id'], procedure_id,
                                         detail=f"Utilisateur en doublon : {duplicate_ids}")
 
 
-def _process_rejection(information: Dict) -> None:
-    save_beneficiary_import_with_status(ImportStatus.REJECTED, information['application_id'], None,
+def _process_rejection(information: Dict, procedure_id: int) -> None:
+    save_beneficiary_import_with_status(ImportStatus.REJECTED, information['application_id'], procedure_id,
                                         detail='Compte existant avec cet email')
     logger.warning(f"[BATCH][REMOTE IMPORT BENEFICIARIES] Rejected application {information['application_id']} because of already existing email")
 
 
-def _process_error(error_messages: List[str], application_id: int) -> None:
+def _process_error(error_messages: List[str], application_id: int, procedure_id: int) -> None:
     error = f"Le dossier {application_id} contient des erreurs et a été ignoré"
     logger.error(f'[BATCH][REMOTE IMPORT BENEFICIARIES] {error}')
     error_messages.append(error)
-    save_beneficiary_import_with_status(ImportStatus.ERROR, application_id, None, detail=error)
+    save_beneficiary_import_with_status(ImportStatus.ERROR, application_id, procedure_id, detail=error)
 
 
 def _find_application_ids_to_process(applications: Dict, process_applications_updated_after: datetime) -> Set:

--- a/scripts/interact.py
+++ b/scripts/interact.py
@@ -33,4 +33,5 @@ from utils.includes import *
 from utils.logger import *
 from utils.token import *
 from scripts.beneficiary import old_remote_import
+from scripts.beneficiary import remote_import
 from scripts.booking import *

--- a/scripts/interact.py
+++ b/scripts/interact.py
@@ -32,5 +32,5 @@ from utils.import_module import *
 from utils.includes import *
 from utils.logger import *
 from utils.token import *
-from scripts.beneficiary import remote_import
+from scripts.beneficiary import old_remote_import
 from scripts.booking import *

--- a/tests/domain/user_activation_test.py
+++ b/tests/domain/user_activation_test.py
@@ -7,7 +7,7 @@ from domain.user_activation import generate_activation_users_csv, is_import_stat
 from models import ImportStatus, EventType, User
 from models import ThingType
 from models.booking import ActivationUser
-from scripts.beneficiary.remote_import import create_beneficiary_from_application
+from scripts.beneficiary.old_remote_import import create_beneficiary_from_application
 from tests.model_creators.generic_creators import create_booking, create_user, create_stock, create_offerer, \
     create_venue
 from tests.model_creators.specific_creators import create_product_with_event_type, create_offer_with_thing_product, \

--- a/tests/repository/beneficiary_import_queries_test.py
+++ b/tests/repository/beneficiary_import_queries_test.py
@@ -119,7 +119,8 @@ class SaveBeneficiaryImportWithStatusTest:
     @clean_database
     def test_a_status_is_set_on_a_new_import(self, app):
         # when
-        save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, None, user=None)
+        save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, demarche_simplifiee_procedure_id=14562,
+                                            user=None)
 
         # then
         beneficiary_import = BeneficiaryImport.query.filter_by(demarcheSimplifieeApplicationId=123).first()
@@ -139,11 +140,13 @@ class SaveBeneficiaryImportWithStatusTest:
         # given
         two_days_ago = datetime.utcnow() - timedelta(days=2)
         with freeze_time(two_days_ago):
-            save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, None, user=None)
+            save_beneficiary_import_with_status(ImportStatus.DUPLICATE, 123, demarche_simplifiee_procedure_id=14562,
+                                                user=None)
         beneficiary = create_user()
 
         # when
-        save_beneficiary_import_with_status(ImportStatus.CREATED, 123, None, user=beneficiary)
+        save_beneficiary_import_with_status(ImportStatus.CREATED, 123, demarche_simplifiee_procedure_id=14562,
+                                            user=beneficiary)
 
         # then
         beneficiary_imports = BeneficiaryImport.query.filter_by(demarcheSimplifieeApplicationId=123).all()
@@ -157,10 +160,12 @@ class SaveBeneficiaryImportWithStatusTest:
         two_days_ago = datetime.utcnow() - timedelta(days=2)
         beneficiary = create_user()
         with freeze_time(two_days_ago):
-            save_beneficiary_import_with_status(ImportStatus.CREATED, 123, None, user=beneficiary)
+            save_beneficiary_import_with_status(ImportStatus.CREATED, 123, demarche_simplifiee_procedure_id=14562,
+                                                user=beneficiary)
 
         # When
-        save_beneficiary_import_with_status(ImportStatus.REJECTED, 123, None, user=None)
+        save_beneficiary_import_with_status(ImportStatus.REJECTED, 123, demarche_simplifiee_procedure_id=14562,
+                                            user=None)
 
         # Then
         beneficiary_imports = BeneficiaryImport.query.filter_by(demarcheSimplifieeApplicationId=123).first()

--- a/tests/repository/user_queries_test.py
+++ b/tests/repository/user_queries_test.py
@@ -1,22 +1,27 @@
-from datetime import datetime, timedelta, MINYEAR
+from datetime import MINYEAR, datetime, timedelta
 
-from models import ImportStatus, ThingType, EventType
+from models import EventType, ImportStatus, ThingType
 from repository import repository
-from repository.user_queries import get_all_users_wallet_balances, find_by_civility, \
-    find_most_recent_beneficiary_creation_date_by_procedure_id, count_all_activated_users, count_users_having_booked, \
-    count_all_activated_users_by_departement, count_users_having_booked_by_departement_code
+from repository.user_queries import \
+    count_all_activated_users, count_all_activated_users_by_departement, \
+    count_users_having_booked, count_users_having_booked_by_departement_code, \
+    find_by_civility, \
+    find_most_recent_beneficiary_creation_date_by_procedure_id, \
+    get_all_users_wallet_balances
 from tests.conftest import clean_database
-from tests.model_creators.generic_creators import create_booking, create_user, create_beneficiary_import, create_stock, \
-    create_offerer, create_venue, create_deposit
-from tests.model_creators.specific_creators import create_offer_with_thing_product, create_offer_with_event_product
+from tests.model_creators.generic_creators import create_beneficiary_import, \
+    create_booking, create_deposit, create_offerer, create_stock, create_user, \
+    create_venue
+from tests.model_creators.specific_creators import \
+    create_offer_with_event_product, create_offer_with_thing_product
 
 
 class GetAllUsersWalletBalancesTest:
     @clean_database
     def test_users_are_sorted_by_user_id(self, app):
         # given
-        user1 = create_user(email='user1@test.com')
-        user2 = create_user(email='user2@test.com')
+        user1 = create_user(email='user1@example.com')
+        user2 = create_user(email='user2@example.com')
         offerer = create_offerer()
         venue = create_venue(offerer)
         offer = create_offer_with_thing_product(venue)
@@ -38,8 +43,8 @@ class GetAllUsersWalletBalancesTest:
     @clean_database
     def test_users_with_no_deposits_are_ignored(self, app):
         # given
-        user1 = create_user(email='user1@test.com')
-        user2 = create_user(email='user2@test.com')
+        user1 = create_user(email='user1@example.com')
+        user2 = create_user(email='user2@example.com')
         offerer = create_offerer()
         venue = create_venue(offerer)
         offer = create_offer_with_thing_product(venue)
@@ -57,8 +62,8 @@ class GetAllUsersWalletBalancesTest:
     @clean_database
     def test_returns_current_balances(self, app):
         # given
-        user1 = create_user(email='user1@test.com')
-        user2 = create_user(email='user2@test.com')
+        user1 = create_user(email='user1@example.com')
+        user2 = create_user(email='user2@example.com')
         offerer = create_offerer()
         venue = create_venue(offerer)
         offer = create_offer_with_thing_product(venue)
@@ -80,8 +85,8 @@ class GetAllUsersWalletBalancesTest:
     @clean_database
     def test_returns_real_balances(self, app):
         # given
-        user1 = create_user(email='user1@test.com')
-        user2 = create_user(email='user2@test.com')
+        user1 = create_user(email='user1@example.com')
+        user2 = create_user(email='user2@example.com')
         offerer = create_offerer()
         venue = create_venue(offerer)
         offer = create_offer_with_thing_product(venue)
@@ -105,9 +110,9 @@ class FindByCivilityTest:
     @clean_database
     def test_returns_users_with_matching_criteria_ignoring_case(self, app):
         # given
-        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@test.com', first_name="john",
+        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@example.com', first_name="john",
                             last_name='DOe')
-        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@test.com', first_name="jaNE",
+        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
                             last_name='DOe')
         repository.save(user1, user2)
 
@@ -116,14 +121,14 @@ class FindByCivilityTest:
 
         # then
         assert len(users) == 1
-        assert users[0].email == 'john@test.com'
+        assert users[0].email == 'john@example.com'
 
     @clean_database
     def test_returns_users_with_matching_criteria_ignoring_dash(self, app):
         # given
-        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@test.com', first_name="jaNE",
+        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
                             last_name='DOe')
-        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@test.com', first_name="john-bob",
+        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@example.com', first_name="john-bob",
                             last_name='doe')
         repository.save(user1, user2)
 
@@ -132,14 +137,14 @@ class FindByCivilityTest:
 
         # then
         assert len(users) == 1
-        assert users[0].email == 'john.b@test.com'
+        assert users[0].email == 'john.b@example.com'
 
     @clean_database
     def test_returns_users_with_matching_criteria_ignoring_spaces(self, app):
         # given
-        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@test.com', first_name="jaNE",
+        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
                             last_name='DOe')
-        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@test.com', first_name="john bob",
+        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@example.com', first_name="john bob",
                             last_name='doe')
         repository.save(user1, user2)
 
@@ -148,14 +153,14 @@ class FindByCivilityTest:
 
         # then
         assert len(users) == 1
-        assert users[0].email == 'john.b@test.com'
+        assert users[0].email == 'john.b@example.com'
 
     @clean_database
     def test_returns_users_with_matching_criteria_ignoring_accents(self, app):
         # given
-        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@test.com', first_name="jaNE",
+        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
                             last_name='DOe')
-        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@test.com', first_name="john bob",
+        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john.b@example.com', first_name="john bob",
                             last_name='doe')
         repository.save(user1, user2)
 
@@ -164,7 +169,7 @@ class FindByCivilityTest:
 
         # then
         assert len(users) == 1
-        assert users[0].email == 'john.b@test.com'
+        assert users[0].email == 'john.b@example.com'
 
     @clean_database
     def test_returns_nothing_if_one_criteria_does_not_match(self, app):
@@ -181,9 +186,9 @@ class FindByCivilityTest:
     @clean_database
     def test_returns_users_with_matching_criteria_first_and_last_names_and_birthdate_and_invalid_email(self, app):
         # given
-        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@test.com', first_name="john",
+        user1 = create_user(date_of_birth=datetime(2000, 5, 1), email='john@example.com', first_name="john",
                             last_name='DOe')
-        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@test.com', first_name="jaNE",
+        user2 = create_user(date_of_birth=datetime(2000, 3, 20), email='jane@example.com', first_name="jaNE",
                             last_name='DOe')
         repository.save(user1, user2)
 
@@ -192,7 +197,7 @@ class FindByCivilityTest:
 
         # then
         assert len(users) == 1
-        assert users[0].email == 'john@test.com'
+        assert users[0].email == 'john@example.com'
 
 
 class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
@@ -227,8 +232,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         assert most_recent_creation_date == three_days_ago
 
     @clean_database
-    def test_returns_min_year_if_no_beneficiary_import_exist_for_given_procedure_id(
-          self, app):
+    def test_returns_min_year_if_no_beneficiary_import_exist_for_given_procedure_id(self, app):
         # given
         old_demarche_simplifiee_procedure_id = 1
         new_demarche_simplifiee_procedure_id = 2
@@ -237,8 +241,8 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
 
         user = create_user(date_created=yesterday, email='user@example.com')
         beneficiary_import = create_beneficiary_import(user=user, status=ImportStatus.CREATED, date=yesterday,
-                                            demarche_simplifiee_application_id=3,
-                                            demarche_simplifiee_procedure_id=old_demarche_simplifiee_procedure_id)
+                                                       demarche_simplifiee_application_id=3,
+                                                       demarche_simplifiee_procedure_id=old_demarche_simplifiee_procedure_id)
 
         repository.save(beneficiary_import)
 
@@ -247,7 +251,6 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
 
         # then
         assert most_recent_creation_date == datetime(MINYEAR, 1, 1)
-
 
     @clean_database
     def test_returns_min_year_if_no_beneficiary_import_exist(self, app):
@@ -268,7 +271,7 @@ class CountAllActivatedUsersTest:
     def test_returns_1_when_only_one_active_user(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True)
-        user_not_activated = create_user(can_book_free_offers=False, email='email2@test.com')
+        user_not_activated = create_user(can_book_free_offers=False, email='email2@example.com')
         repository.save(user_activated, user_not_activated)
 
         # When
@@ -281,7 +284,7 @@ class CountAllActivatedUsersTest:
     def test_returns_0_when_no_active_user(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=False)
-        user_not_activated = create_user(can_book_free_offers=False, email='email2@test.com')
+        user_not_activated = create_user(can_book_free_offers=False, email='email2@example.com')
         repository.save(user_activated, user_not_activated)
 
         # When
@@ -296,7 +299,7 @@ class CountActivatedUsersByDepartementTest:
     def test_returns_1_when_only_one_active_user_in_departement(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True, departement_code='74')
-        user_not_activated = create_user(can_book_free_offers=False, email='email2@test.com')
+        user_not_activated = create_user(can_book_free_offers=False, email='email2@example.com')
         repository.save(user_activated, user_not_activated)
 
         # When
@@ -306,10 +309,10 @@ class CountActivatedUsersByDepartementTest:
         assert number_of_active_users == 1
 
     @clean_database
-    def test_returns_0_when_no_active_user_in_departement(self, app):
+    def test_returns_0_when_no_active_user_in_departement_74(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=False, departement_code='74')
-        user_not_activated = create_user(can_book_free_offers=False, email='email2@test.com')
+        user_not_activated = create_user(can_book_free_offers=False, email='email2@example.com')
         repository.save(user_activated, user_not_activated)
 
         # When
@@ -319,10 +322,10 @@ class CountActivatedUsersByDepartementTest:
         assert number_of_active_users == 0
 
     @clean_database
-    def test_returns_0_when_no_active_user_in_departement(self, app):
+    def test_returns_0_when_no_active_user_in_departement_76(self, app):
         # Given
         user_activated = create_user(can_book_free_offers=True, departement_code='76')
-        user_not_activated = create_user(can_book_free_offers=False, email='email2@test.com')
+        user_not_activated = create_user(can_book_free_offers=False, email='email2@example.com')
         repository.save(user_activated, user_not_activated)
 
         # When

--- a/tests/repository/user_queries_test.py
+++ b/tests/repository/user_queries_test.py
@@ -6,7 +6,7 @@ from repository.user_queries import \
     count_all_activated_users, count_all_activated_users_by_departement, \
     count_users_having_booked, count_users_having_booked_by_departement_code, \
     find_by_civility, \
-    find_most_recent_beneficiary_creation_date_by_procedure_id, \
+    find_most_recent_beneficiary_creation_date_for_procedure_id, \
     get_all_users_wallet_balances
 from tests.conftest import clean_database
 from tests.model_creators.generic_creators import create_beneficiary_import, \
@@ -226,7 +226,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         repository.save(user1, *beneficiary_import)
 
         # when
-        most_recent_creation_date = find_most_recent_beneficiary_creation_date_by_procedure_id(demarche_simplifiee_procedure_id)
+        most_recent_creation_date = find_most_recent_beneficiary_creation_date_for_procedure_id(demarche_simplifiee_procedure_id)
 
         # then
         assert most_recent_creation_date == three_days_ago
@@ -247,7 +247,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         repository.save(beneficiary_import)
 
         # when
-        most_recent_creation_date = find_most_recent_beneficiary_creation_date_by_procedure_id(new_demarche_simplifiee_procedure_id)
+        most_recent_creation_date = find_most_recent_beneficiary_creation_date_for_procedure_id(new_demarche_simplifiee_procedure_id)
 
         # then
         assert most_recent_creation_date == datetime(MINYEAR, 1, 1)
@@ -260,7 +260,7 @@ class FindMostRecentBeneficiaryCreationDateByProcedureIdTest:
         repository.save(user)
 
         # when
-        most_recent_creation_date = find_most_recent_beneficiary_creation_date_by_procedure_id(1)
+        most_recent_creation_date = find_most_recent_beneficiary_creation_date_for_procedure_id(1)
 
         # then
         assert most_recent_creation_date == datetime(MINYEAR, 1, 1)

--- a/tests/scripts/beneficiary/fixture.py
+++ b/tests/scripts/beneficiary/fixture.py
@@ -1,227 +1,232 @@
 import copy
+from typing import Dict
 
 APPLICATION_DETAIL_STANDARD_RESPONSE = {
-  "dossier": {
-    "id": 123,
-    "created_at": "2020-04-17T07:18:22.534Z",
-    "updated_at": "2020-04-17T07:20:33.051Z",
-    "archived": False,
-    "email": "john.doe@test.com",
-    "state": "closed",
-    "simplified_state": "Accepté",
-    "initiated_at": "2020-04-17T07:20:31.996Z",
-    "received_at": None,
-    "processed_at": None,
-    "motivation": None,
-    "instructeurs": [],
-    "individual": {
-      "civilite": "M.",
-      "nom": "Doe",
-      "prenom": "John"
-    },
-    "entreprise": None,
-    "etablissement": None,
-    "cerfa": [],
-    "commentaires": [
-      {
-        "email": "contact@demarches-simplifiees.fr",
-        "body": "[Votre préinscription pour le pass Culture a bien été reçue]\u003cbr\u003e\u003cbr\u003e\u003cp\u003e\r\nBonjour Adrien,\u003c/p\u003e\r\n\u003cp\u003e\r\nL'équipe du pass Culture vous confirme la bonne réception de votre dossier nº 1613447. \u003c/p\u003e\u003cp\u003eVotre dossier sera examiné \u003cb\u003edans les semaines à venir\u003c/b\u003e. Un mail de confirmation vous sera envoyé à l’ouverture de votre pass Culture. À tout moment, vous pouvez consulter l'avancée de votre dossier : \u003ca target=\"_blank\" rel=\"noopener\" href=\"https://www.demarches-simplifiees.fr/dossiers/1613447\"\u003ehttps://www.demarches-simplifiees.fr/dossiers/1613447\u003c/a\u003e\u003c/p\u003e\u003cp\u003eNous vous invitons à consulter notre FAQ, vous y trouverez toutes les informations relatives au pass Culture : \u003ca target=\"_blank\" rel=\"nofollow\" href=\"https://docs.passculture.app/experimentateurs/pre-inscription-au-pass-culture\"\u003ehttps://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/\u003c/a\u003e\u003c/p\u003e\u003cp\u003eVous avez des questions ? Vous pouvez échanger directement avec nous à cette adresse : \u003cb\u003esupport@passculture.app\u003c/b\u003e\u003cbr\u003e\u003c/p\u003e\u003cp\u003eBonne journée,\u003cbr\u003e\u003c/p\u003e\u003cp\u003eL'équipe du pass Culture\u003c/p\u003e",
-        "created_at": "2020-04-17T07:20:33.049Z",
-        "attachment": None
-      }
-    ],
-    "champs_private": [],
-    "pieces_justificatives": [],
-    "types_de_piece_justificative": [],
-    "avis": [],
-    "champs": [
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 609447,
-          "libelle": "Comment remplir ce formulaire de pré-inscription au pass Culture",
-          "type_champ": "explication",
-          "order_place": 0,
-          "description": "Une aide pour remplir votre dossier est disponible ici : https://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/​"
-        }
-      },
-      {
-        "value": "93 - Seine-Saint-Denis",
-        "type_de_champ": {
-          "id": 596453,
-          "libelle": "Veuillez indiquer votre département de résidence",
-          "type_champ": "drop_down_list",
-          "order_place": 1,
-          "description": "Attention, si votre département ne se trouve pas dans cette liste, c'est que vous n'êtes malheureusement pas encore éligible au pass Culture."
-        }
-      },
-      {
-        "value": "2000-05-01",
-        "type_de_champ": {
-          "id": 582220,
-          "libelle": "Quelle est votre date de naissance",
-          "type_champ": "date",
-          "order_place": 2,
-          "description": "Le pass Culture n'est éligible qu'aux personnes ayant 18 ans."
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 718222,
-          "libelle": "Pièces justificatives acceptées",
-          "type_champ": "explication",
-          "order_place": 3,
-          "description": "Pour valider votre inscription, vous devez obligatoirement fournir l'un des documents suivants :\n - carte nationale d'identité ou passeport français ;\n - carte nationale d'identité ou passeport de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse ;\n - titre de séjour français."
-        }
-      },
-      {
-        "value": "http://fake.url",
-        "type_de_champ": {
-          "id": 459819,
-          "libelle": "Pièce d'identité (photocopie de la page avec votre photo)",
-          "type_champ": "piece_justificative",
-          "order_place": 4,
-          "description": "Vos nom, prénom et date de naissance doivent être clairement identifiables. \nN'envoyez PAS le verso de votre carte d'identité ni la couverture de votre passeport."
-        }
-      },
-      {
-        "value": "0123456789",
-        "type_de_champ": {
-          "id": 582219,
-          "libelle": "Quel est votre numéro de téléphone",
-          "type_champ": "phone",
-          "order_place": 5,
-          "description": ""
-        }
-      },
-      {
-        "value": 93130,
-        "type_de_champ": {
-          "id": 582221,
-          "libelle": "Quel est le code postal de votre commune de résidence ?",
-          "type_champ": "integer_number",
-          "order_place": 6,
-          "description": None
-        }
-      },
-      {
-        "value": "35 Rue Saint Denis 93130 Noisy-le-Sec",
-        "type_de_champ": {
-          "id": 582223,
-          "libelle": "Quelle est votre adresse de résidence",
-          "type_champ": "address",
-          "order_place": 7,
-          "description": None
-        }
-      },
-      {
-        "value": "Employé",
-        "type_de_champ": {
-          "id": 718094,
-          "libelle": "Veuillez indiquer votre statut",
-          "type_champ": "drop_down_list",
-          "order_place": 8,
-          "description": ""
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 451284,
-          "libelle": "Déclaration de résidence",
-          "type_champ": "header_section",
-          "order_place": 9,
-          "description": ""
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 582328,
-          "libelle": "Certification sur l'honneur",
-          "type_champ": "explication",
-          "order_place": 10,
-          "description": "Le pass Culture est actuellement en phase d'expérimentation, et n'est disponible que dans certains départements pilotes. Il s'étendra progressivement à l'ensemble du territoire français.\n\nLa liste des départements ouverts à l'expérimentation du pass Culture est disponible ici : https://aide.passculture.app/fr/article/18-ans-puis-je-beneficier-du-pass-culture-16uinm8/"
-        }
-      },
-      {
-        "value": "on",
-        "type_de_champ": {
-          "id": 718106,
-          "libelle": "Je certifie sur l’honneur résider dans l'un des départements ouverts à l'expérimentation du pass Culture.",
-          "type_champ": "engagement",
-          "order_place": 11,
-          "description": "Des contrôles aléatoires seront effectués et vous devrez alors fournir un justificatif de domicile. En cas de fraude, vous vous exposez à des poursuites judiciaires."
-        }
-      },
-      {
-        "value": "on",
-        "type_de_champ": {
-          "id": 718254,
-          "libelle": "Je certifie sur l’honneur résider légalement et habituellement sur le territoire français depuis plus de un an.",
-          "type_champ": "engagement",
-          "order_place": 12,
-          "description": "Cette condition est obligatoire si vous n'êtes pas un ressortissant de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse."
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 466695,
-          "libelle": "Consentement à l'utilisation de mes données",
-          "type_champ": "header_section",
-          "order_place": 13,
-          "description": ""
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 466635,
-          "libelle": "Que faisons-nous de ces données ?",
-          "type_champ": "explication",
-          "order_place": 14,
-          "description": "Ces données sont utilisées à la seule fin de nous assurer de votre éligibilité à l'expérimentation du pass Culture. Vos données seront contrôlées par l'équipe du pass Culture, puis conservées pendant un an à des fins de contrôle a posteriori."
-        }
-      },
-      {
-        "value": "on",
-        "type_de_champ": {
-          "id": 466694,
-          "libelle": "Je donne mon accord au traitement de mes données à caractère personnel dans les conditions explicitées ci-dessus",
-          "type_champ": "engagement",
-          "order_place": 15,
-          "description": ""
-        }
-      },
-      {
-        "value": "on",
-        "type_de_champ": {
-          "id": 457303,
-          "libelle": "Je déclare sur l’honneur que ces documents sont authentiques. ",
-          "type_champ": "engagement",
-          "order_place": 16,
-          "description": ""
-        }
-      },
-      {
-        "value": None,
-        "type_de_champ": {
-          "id": 454775,
-          "libelle": "Un grand merci et à très vite sur le pass Culture !",
-          "type_champ": "header_section",
-          "order_place": 17,
-          "description": ""
-        }
-      }
-    ]
-  }
+    "dossier": {
+        "id": 123,
+        "created_at": "2020-04-17T07:18:22.534Z",
+        "updated_at": "2020-04-17T07:20:33.051Z",
+        "archived": False,
+        "email": "john.doe@test.com",
+        "state": "closed",
+        "simplified_state": "Accepté",
+        "initiated_at": "2020-04-17T07:20:31.996Z",
+        "received_at": None,
+        "processed_at": None,
+        "motivation": None,
+        "instructeurs": [],
+        "individual": {
+            "civilite": "M.",
+            "nom": "Doe",
+            "prenom": "John"
+        },
+        "entreprise": None,
+        "etablissement": None,
+        "cerfa": [],
+        "commentaires": [
+            {
+                "email": "contact@demarches-simplifiees.fr",
+                "body": "[Votre préinscription pour le pass Culture a bien été reçue]\u003cbr\u003e\u003cbr\u003e\u003cp\u003e\r\nBonjour Adrien,\u003c/p\u003e\r\n\u003cp\u003e\r\nL'équipe du pass Culture vous confirme la bonne réception de votre dossier nº 1613447. \u003c/p\u003e\u003cp\u003eVotre dossier sera examiné \u003cb\u003edans les semaines à venir\u003c/b\u003e. Un mail de confirmation vous sera envoyé à l’ouverture de votre pass Culture. À tout moment, vous pouvez consulter l'avancée de votre dossier : \u003ca target=\"_blank\" rel=\"noopener\" href=\"https://www.demarches-simplifiees.fr/dossiers/1613447\"\u003ehttps://www.demarches-simplifiees.fr/dossiers/1613447\u003c/a\u003e\u003c/p\u003e\u003cp\u003eNous vous invitons à consulter notre FAQ, vous y trouverez toutes les informations relatives au pass Culture : \u003ca target=\"_blank\" rel=\"nofollow\" href=\"https://docs.passculture.app/experimentateurs/pre-inscription-au-pass-culture\"\u003ehttps://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/\u003c/a\u003e\u003c/p\u003e\u003cp\u003eVous avez des questions ? Vous pouvez échanger directement avec nous à cette adresse : \u003cb\u003esupport@passculture.app\u003c/b\u003e\u003cbr\u003e\u003c/p\u003e\u003cp\u003eBonne journée,\u003cbr\u003e\u003c/p\u003e\u003cp\u003eL'équipe du pass Culture\u003c/p\u003e",
+                "created_at": "2020-04-17T07:20:33.049Z",
+                "offerer_attachment_validationhment": None
+            }
+        ],
+        "champs_private": [],
+        "pieces_justificatives": [],
+        "types_de_piece_justificative": [],
+        "avis": [],
+        "champs": [
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 609447,
+                    "libelle": "Comment remplir ce formulaire de pré-inscription au pass Culture",
+                    "type_champ": "explication",
+                    "order_place": 0,
+                    "description": "Une aide pour remplir votre dossier est disponible ici : https://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/​"
+                }
+            },
+            {
+                "value": "93 - Seine-Saint-Denis",
+                "type_de_champ": {
+                    "id": 596453,
+                    "libelle": "Veuillez indiquer votre département de résidence",
+                    "type_champ": "drop_down_list",
+                    "order_place": 1,
+                    "description": "Attention, si votre département ne se trouve pas dans cette liste, c'est que vous n'êtes malheureusement pas encore éligible au pass Culture."
+                }
+            },
+            {
+                "value": "2000-05-01",
+                "type_de_champ": {
+                    "id": 582220,
+                    "libelle": "Quelle est votre date de naissance",
+                    "type_champ": "date",
+                    "order_place": 2,
+                    "description": "Le pass Culture n'est éligible qu'aux personnes ayant 18 ans."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 718222,
+                    "libelle": "Pièces justificatives acceptées",
+                    "type_champ": "explication",
+                    "order_place": 3,
+                    "description": "Pour valider votre inscription, vous devez obligatoirement fournir l'un des documents suivants :\n - carte nationale d'identité ou passeport français ;\n - carte nationale d'identité ou passeport de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse ;\n - titre de séjour français."
+                }
+            },
+            {
+                "value": "http://fake.url",
+                "type_de_champ": {
+                    "id": 459819,
+                    "libelle": "Pièce d'identité (photocopie de la page avec votre photo)",
+                    "type_champ": "piece_justificative",
+                    "order_place": 4,
+                    "description": "Vos nom, prénom et date de naissance doivent être clairement identifiables. \nN'envoyez PAS le verso de votre carte d'identité ni la couverture de votre passeport."
+                }
+            },
+            {
+                "value": "0123456789",
+                "type_de_champ": {
+                    "id": 582219,
+                    "libelle": "Quel est votre numéro de téléphone",
+                    "type_champ": "phone",
+                    "order_place": 5,
+                    "description": ""
+                }
+            },
+            {
+                "value": 93130,
+                "type_de_champ": {
+                    "id": 582221,
+                    "libelle": "Quel est le code postal de votre commune de résidence ?",
+                    "type_champ": "integer_number",
+                    "order_place": 6,
+                    "description": None
+                }
+            },
+            {
+                "value": "35 Rue Saint Denis 93130 Noisy-le-Sec",
+                "type_de_champ": {
+                    "id": 582223,
+                    "libelle": "Quelle est votre adresse de résidence",
+                    "type_champ": "address",
+                    "order_place": 7,
+                    "description": None
+                }
+            },
+            {
+                "value": "Employé",
+                "type_de_champ": {
+                    "id": 718094,
+                    "libelle": "Veuillez indiquer votre statut",
+                    "type_champ": "drop_down_list",
+                    "order_place": 8,
+                    "description": ""
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 451284,
+                    "libelle": "Déclaration de résidence",
+                    "type_champ": "header_section",
+                    "order_place": 9,
+                    "description": ""
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 582328,
+                    "libelle": "Certification sur l'honneur",
+                    "type_champ": "explication",
+                    "order_place": 10,
+                    "description": "Le pass Culture est actuellement en phase d'expérimentation, et n'est disponible que dans certains départements pilotes. Il s'étendra progressivement à l'ensemble du territoire français.\n\nLa liste des départements ouverts à l'expérimentation du pass Culture est disponible ici : https://aide.passculture.app/fr/article/18-ans-puis-je-beneficier-du-pass-culture-16uinm8/"
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 718106,
+                    "libelle": "Je certifie sur l’honneur résider dans l'un des départements ouverts à l'expérimentation du pass Culture.",
+                    "type_champ": "engagement",
+                    "order_place": 11,
+                    "description": "Des contrôles aléatoires seront effectués et vous devrez alors fournir un justificatif de domicile. En cas de fraude, vous vous exposez à des poursuites judiciaires."
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 718254,
+                    "libelle": "Je certifie sur l’honneur résider légalement et habituellement sur le territoire français depuis plus de un an.",
+                    "type_champ": "engagement",
+                    "order_place": 12,
+                    "description": "Cette condition est obligatoire si vous n'êtes pas un ressortissant de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 466695,
+                    "libelle": "Consentement à l'utilisation de mes données",
+                    "type_champ": "header_section",
+                    "order_place": 13,
+                    "description": ""
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 466635,
+                    "libelle": "Que faisons-nous de ces données ?",
+                    "type_champ": "explication",
+                    "order_place": 14,
+                    "description": "Ces données sont utilisées à la seule fin de nous assurer de votre éligibilité à l'expérimentation du pass Culture. Vos données seront contrôlées par l'équipe du pass Culture, puis conservées pendant un an à des fins de contrôle a posteriori."
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 466694,
+                    "libelle": "Je donne mon accord au traitement de mes données à caractère personnel dans les conditions explicitées ci-dessus",
+                    "type_champ": "engagement",
+                    "order_place": 15,
+                    "description": ""
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 457303,
+                    "libelle": "Je déclare sur l’honneur que ces documents sont authentiques. ",
+                    "type_champ": "engagement",
+                    "order_place": 16,
+                    "description": ""
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 454775,
+                    "libelle": "Un grand merci et à très vite sur le pass Culture !",
+                    "type_champ": "header_section",
+                    "order_place": 17,
+                    "description": ""
+                }
+            }
+        ]
+    }
 }
 
-def \
-        make_new_beneficiary_application_details(id: int, state: str, postal_code=67200, department_code='67 - Bas-Rhin',
-                            civility='Mme', activity='Étudiant') -> dict:
+
+def make_new_beneficiary_application_details(id: int,
+                                             state: str,
+                                             postal_code: int = 67200,
+                                             department_code: str = '67 - Bas-Rhin',
+                                             civility: str = 'Mme',
+                                             activity: str = 'Étudiant') -> Dict:
     application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
     application['dossier']['id'] = id
     application['dossier']['state'] = state

--- a/tests/scripts/beneficiary/fixture.py
+++ b/tests/scripts/beneficiary/fixture.py
@@ -1,277 +1,235 @@
 import copy
 
 APPLICATION_DETAIL_STANDARD_RESPONSE = {
-    "dossier": {
-        "id": 123,
-        "created_at": "2019-05-04T17:57:28.726Z",
-        "updated_at": "2019-05-07T15:15:39.849Z",
-        "archived": False,
-        "email": "jane.doe@test.com",
-        "state": "closed",
-        "simplified_state": "Accepté",
-        "initiated_at": "2019-05-04T18:01:23.694Z",
-        "received_at": "2019-05-07T15:15:22.340Z",
-        "processed_at": "2019-05-07T15:15:39.393Z",
-        "motivation": "",
-        "instructeurs": ["admin.pc@example.com"],
-        "individual": {"civilite": "Mme", "nom": "Doe", "prenom": "Jane"},
-        "entreprise": None,
-        "etablissement": None, "cerfa": [], "commentaires": [
-            {
-                "email": "contact@demarches-simplifiees.fr",
-                "body": "...",
-                "created_at": "2019-05-04T18:01:24.428Z",
-                "attachment": None
-            },
-            {
-                "email": "contact@demarches-simplifiees.fr",
-                "body": "...",
-                "created_at": "2019-05-07T15:15:22.504Z",
-                "attachment": None
-            },
-            {
-                "email": "contact@demarches-simplifiees.fr",
-                "body": "...",
-                "created_at": "2019-05-07T15:15:39.845Z",
-                "attachment": None
-            }
-        ],
-        "champs_private": [],
-        "pieces_justificatives": [],
-        "types_de_piece_justificative": [],
-        "justificatif_motivation": None,
-        "champs": [
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 609447,
-                    "libelle": "Comment remplir ce formulaire de pré-inscription au pass Culture",
-                    "type_champ": "explication", "order_place": 0,
-                    "description": "Une aide pour remplir votre dossier est disponible ici : https://docs.passculture.app/experimentateurs/pre-inscription"}
-            },
-            {
-                "value": "94 - Val-de-Marne",
-                "type_de_champ": {
-                    "id": 596453, "libelle": "Veuillez indiquer votre département",
-                    "type_champ": "departements", "order_place": 1,
-                    "description": "Département de résidence (vous devrez fournir un justificatif de domicile)."
-                }
-            },
-            {
-                "value": "0123456789",
-                "type_de_champ": {
-                    "id": 582219, "libelle": "Numéro de téléphone",
-                    "type_champ": "phone", "order_place": 2, "description": ""
-                }
-            },
-            {
-                "value": "2000-05-01",
-                "type_de_champ": {
-                    "id": 582220, "libelle": "Date de naissance", "type_champ": "date",
-                    "order_place": 3,
-                    "description": "Assurez-vous de bien sélectionner votre année de naissance."
-                }
-            },
-            {
-                "value": "94200",
-                "type_de_champ": {
-                    "id": 639254, "libelle": "Code postal de votre lieu de naissance",
-                    "type_champ": "text", "order_place": 4, "description": None
-                }
-            },
-            {
-                "value": "Étudiant",
-                "type_de_champ":
-                    {
-                        "id":718094,
-                        "libelle":"Veuillez indiquer votre statut",
-                        "type_champ":"drop_down_list",
-                        "order_place":7,
-                        "description":""
-                    }
-            },
-            {
-                "value": "6 rue de la République",
-                "type_de_champ": {
-                    "id": 582223, "libelle": "Adresse de résidence",
-                    "type_champ": "address", "order_place": 5, "description": None
-                }
-            },
-            {
-                "value": "67200",
-                "type_de_champ": {
-                    "id": 582221,
-                    "libelle": "Code postal de votre adresse de résidence",
-                    "type_champ": "text", "order_place": 6,
-                    "description": None
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 582328,
-                    "libelle": "Pièces justificatives",
-                    "type_champ": "explication",
-                    "order_place": 7,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 609392, "libelle": "1. Pièce d'identité",
-                    "type_champ": "header_section", "order_place": 8,
-                    "description": None
-                }
-            },
-            {
-                "value": "http://fake.url",
-                "type_de_champ": {
-                    "id": 459819,
-                    "libelle": "Pièce d'identité (numérisation RECTO seul de votre carte d'identité ou passeport)",
-                    "type_champ": "piece_justificative", "order_place": 9,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 451284,
-                    "libelle": "2.1 Si vous avez un justificatif de domicile à votre nom :",
-                    "type_champ": "header_section", "order_place": 10,
-                    "description": ""
-                }
-            },
-            {
-                "value": "http://fake.url",
-                "type_de_champ": {
-                    "id": 422858,
-                    "libelle": "Justificatif de domicile à votre nom et prénom",
-                    "type_champ": "piece_justificative", "order_place": 11,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 460834,
-                    "libelle": "2.2 Sinon, si vous habitez chez un proche (parent, ami, etc.) :",
-                    "type_champ": "header_section", "order_place": 12,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 460835,
-                    "libelle": "Justificatif de domicile de la personne qui vous héberge",
-                    "type_champ": "piece_justificative",
-                    "order_place": 13,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 451287,
-                    "libelle": "Attestation sur l'honneur d'hébergement, datée et signée par la personne qui vous héberge et par vous-même",
-                    "type_champ": "piece_justificative",
-                    "order_place": 14,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 451288,
-                    "libelle": "Pièce d'identité de la personne qui vous héberge",
-                    "type_champ": "piece_justificative",
-                    "order_place": 15,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 460836,
-                    "libelle": "Vous n'êtes pas de nationalité française ?",
-                    "type_champ": "header_section", "order_place": 16,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 451286,
-                    "libelle": "Justificatif de présence sur le territoire français depuis plus d'un an",
-                    "type_champ": "piece_justificative",
-                    "order_place": 17,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 466695,
-                    "libelle": "Consentement à l'utilisation de mes données",
-                    "type_champ": "header_section", "order_place": 18,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-
-                "type_de_champ": {
-                    "id": 466635,
-                    "libelle": "Que faisons-nous de ces données ?",
-                    "type_champ": "explication",
-                    "order_place": 19,
-                    "description": "..."
-                }
-            },
-            {
-                "value": "on",
-                "type_de_champ": {
-                    "id": 466694,
-                    "libelle": "Je donne mon accord au traitement de mes données à caractère personnel dans les conditions explicitées ci-dessus",
-                    "type_champ": "engagement", "order_place": 20,
-                    "description": "..."
-                }
-            },
-            {
-                "value": "on",
-                "type_de_champ": {
-                    "id": 457303,
-                    "libelle": "Je déclare sur l’honneur que ces documents sont authentiques. ",
-                    "type_champ": "engagement",
-                    "order_place": 21,
-                    "description": "..."
-                }
-            },
-            {
-                "value": None,
-                "type_de_champ": {
-                    "id": 454775,
-                    "libelle": "Un grand merci et à très vite sur le pass Culture !",
-                    "type_champ": "header_section", "order_place": 22,
-                    "description": "..."
-                }
-            }
-        ]
-    }
+  "dossier": {
+    "id": 123,
+    "created_at": "2020-04-17T07:18:22.534Z",
+    "updated_at": "2020-04-17T07:20:33.051Z",
+    "archived": False,
+    "email": "john.doe@test.com",
+    "state": "closed",
+    "simplified_state": "Accepté",
+    "initiated_at": "2020-04-17T07:20:31.996Z",
+    "received_at": None,
+    "processed_at": None,
+    "motivation": None,
+    "instructeurs": [],
+    "individual": {
+      "civilite": "M.",
+      "nom": "Doe",
+      "prenom": "John"
+    },
+    "entreprise": None,
+    "etablissement": None,
+    "cerfa": [],
+    "commentaires": [
+      {
+        "email": "contact@demarches-simplifiees.fr",
+        "body": "[Votre préinscription pour le pass Culture a bien été reçue]\u003cbr\u003e\u003cbr\u003e\u003cp\u003e\r\nBonjour Adrien,\u003c/p\u003e\r\n\u003cp\u003e\r\nL'équipe du pass Culture vous confirme la bonne réception de votre dossier nº 1613447. \u003c/p\u003e\u003cp\u003eVotre dossier sera examiné \u003cb\u003edans les semaines à venir\u003c/b\u003e. Un mail de confirmation vous sera envoyé à l’ouverture de votre pass Culture. À tout moment, vous pouvez consulter l'avancée de votre dossier : \u003ca target=\"_blank\" rel=\"noopener\" href=\"https://www.demarches-simplifiees.fr/dossiers/1613447\"\u003ehttps://www.demarches-simplifiees.fr/dossiers/1613447\u003c/a\u003e\u003c/p\u003e\u003cp\u003eNous vous invitons à consulter notre FAQ, vous y trouverez toutes les informations relatives au pass Culture : \u003ca target=\"_blank\" rel=\"nofollow\" href=\"https://docs.passculture.app/experimentateurs/pre-inscription-au-pass-culture\"\u003ehttps://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/\u003c/a\u003e\u003c/p\u003e\u003cp\u003eVous avez des questions ? Vous pouvez échanger directement avec nous à cette adresse : \u003cb\u003esupport@passculture.app\u003c/b\u003e\u003cbr\u003e\u003c/p\u003e\u003cp\u003eBonne journée,\u003cbr\u003e\u003c/p\u003e\u003cp\u003eL'équipe du pass Culture\u003c/p\u003e",
+        "created_at": "2020-04-17T07:20:33.049Z",
+        "attachment": None
+      }
+    ],
+    "champs_private": [],
+    "pieces_justificatives": [],
+    "types_de_piece_justificative": [],
+    "avis": [],
+    "champs": [
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 609447,
+          "libelle": "Comment remplir ce formulaire de pré-inscription au pass Culture",
+          "type_champ": "explication",
+          "order_place": 0,
+          "description": "Une aide pour remplir votre dossier est disponible ici : https://aide.passculture.app/fr/article/18-ans-ma-pre-inscription-au-pass-culture-fj3mqc/​"
+        }
+      },
+      {
+        "value": "93 - Seine-Saint-Denis",
+        "type_de_champ": {
+          "id": 596453,
+          "libelle": "Veuillez indiquer votre département de résidence",
+          "type_champ": "drop_down_list",
+          "order_place": 1,
+          "description": "Attention, si votre département ne se trouve pas dans cette liste, c'est que vous n'êtes malheureusement pas encore éligible au pass Culture."
+        }
+      },
+      {
+        "value": "2000-05-01",
+        "type_de_champ": {
+          "id": 582220,
+          "libelle": "Quelle est votre date de naissance",
+          "type_champ": "date",
+          "order_place": 2,
+          "description": "Le pass Culture n'est éligible qu'aux personnes ayant 18 ans."
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 718222,
+          "libelle": "Pièces justificatives acceptées",
+          "type_champ": "explication",
+          "order_place": 3,
+          "description": "Pour valider votre inscription, vous devez obligatoirement fournir l'un des documents suivants :\n - carte nationale d'identité ou passeport français ;\n - carte nationale d'identité ou passeport de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse ;\n - titre de séjour français."
+        }
+      },
+      {
+        "value": "http://fake.url",
+        "type_de_champ": {
+          "id": 459819,
+          "libelle": "Pièce d'identité (photocopie de la page avec votre photo)",
+          "type_champ": "piece_justificative",
+          "order_place": 4,
+          "description": "Vos nom, prénom et date de naissance doivent être clairement identifiables. \nN'envoyez PAS le verso de votre carte d'identité ni la couverture de votre passeport."
+        }
+      },
+      {
+        "value": "0123456789",
+        "type_de_champ": {
+          "id": 582219,
+          "libelle": "Quel est votre numéro de téléphone",
+          "type_champ": "phone",
+          "order_place": 5,
+          "description": ""
+        }
+      },
+      {
+        "value": 93130,
+        "type_de_champ": {
+          "id": 582221,
+          "libelle": "Quel est le code postal de votre commune de résidence ?",
+          "type_champ": "integer_number",
+          "order_place": 6,
+          "description": None
+        }
+      },
+      {
+        "value": "35 Rue Saint Denis 93130 Noisy-le-Sec",
+        "type_de_champ": {
+          "id": 582223,
+          "libelle": "Quelle est votre adresse de résidence",
+          "type_champ": "address",
+          "order_place": 7,
+          "description": None
+        }
+      },
+      {
+        "value": "Employé",
+        "type_de_champ": {
+          "id": 718094,
+          "libelle": "Veuillez indiquer votre statut",
+          "type_champ": "drop_down_list",
+          "order_place": 8,
+          "description": ""
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 451284,
+          "libelle": "Déclaration de résidence",
+          "type_champ": "header_section",
+          "order_place": 9,
+          "description": ""
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 582328,
+          "libelle": "Certification sur l'honneur",
+          "type_champ": "explication",
+          "order_place": 10,
+          "description": "Le pass Culture est actuellement en phase d'expérimentation, et n'est disponible que dans certains départements pilotes. Il s'étendra progressivement à l'ensemble du territoire français.\n\nLa liste des départements ouverts à l'expérimentation du pass Culture est disponible ici : https://aide.passculture.app/fr/article/18-ans-puis-je-beneficier-du-pass-culture-16uinm8/"
+        }
+      },
+      {
+        "value": "on",
+        "type_de_champ": {
+          "id": 718106,
+          "libelle": "Je certifie sur l’honneur résider dans l'un des départements ouverts à l'expérimentation du pass Culture.",
+          "type_champ": "engagement",
+          "order_place": 11,
+          "description": "Des contrôles aléatoires seront effectués et vous devrez alors fournir un justificatif de domicile. En cas de fraude, vous vous exposez à des poursuites judiciaires."
+        }
+      },
+      {
+        "value": "on",
+        "type_de_champ": {
+          "id": 718254,
+          "libelle": "Je certifie sur l’honneur résider légalement et habituellement sur le territoire français depuis plus de un an.",
+          "type_champ": "engagement",
+          "order_place": 12,
+          "description": "Cette condition est obligatoire si vous n'êtes pas un ressortissant de l'un des Etats membres de l'Union européenne ou de l'un des Etats parties à l'accord sur l'Espace économique européen ou de la Confédération suisse."
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 466695,
+          "libelle": "Consentement à l'utilisation de mes données",
+          "type_champ": "header_section",
+          "order_place": 13,
+          "description": ""
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 466635,
+          "libelle": "Que faisons-nous de ces données ?",
+          "type_champ": "explication",
+          "order_place": 14,
+          "description": "Ces données sont utilisées à la seule fin de nous assurer de votre éligibilité à l'expérimentation du pass Culture. Vos données seront contrôlées par l'équipe du pass Culture, puis conservées pendant un an à des fins de contrôle a posteriori."
+        }
+      },
+      {
+        "value": "on",
+        "type_de_champ": {
+          "id": 466694,
+          "libelle": "Je donne mon accord au traitement de mes données à caractère personnel dans les conditions explicitées ci-dessus",
+          "type_champ": "engagement",
+          "order_place": 15,
+          "description": ""
+        }
+      },
+      {
+        "value": "on",
+        "type_de_champ": {
+          "id": 457303,
+          "libelle": "Je déclare sur l’honneur que ces documents sont authentiques. ",
+          "type_champ": "engagement",
+          "order_place": 16,
+          "description": ""
+        }
+      },
+      {
+        "value": None,
+        "type_de_champ": {
+          "id": 454775,
+          "libelle": "Un grand merci et à très vite sur le pass Culture !",
+          "type_champ": "header_section",
+          "order_place": 17,
+          "description": ""
+        }
+      }
+    ]
+  }
 }
 
-
-def make_application_detail(id: int, state: str, postal_code='67200', department_code='67 - Bas-Rhin',
+def \
+        make_new_beneficiary_application_details(id: int, state: str, postal_code=67200, department_code='67 - Bas-Rhin',
                             civility='Mme', activity='Étudiant') -> dict:
     application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
     application['dossier']['id'] = id
     application['dossier']['state'] = state
     application['dossier']['individual']['civilite'] = civility
     for field in application['dossier']['champs']:
-        if field['type_de_champ']['libelle'] == 'Veuillez indiquer votre département':
+        if field['type_de_champ']['libelle'] == 'Veuillez indiquer votre département de résidence':
             field['value'] = department_code
-        if field['type_de_champ']['libelle'] == 'Code postal de votre adresse de résidence':
+        if field['type_de_champ']['libelle'] == 'Quel est le code postal de votre commune de résidence ?':
             field['value'] = postal_code
         if field['type_de_champ']['libelle'] == 'Veuillez indiquer votre statut':
             field['value'] = activity

--- a/tests/scripts/beneficiary/old_remote_fixture.py
+++ b/tests/scripts/beneficiary/old_remote_fixture.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Dict
 
 APPLICATION_DETAIL_STANDARD_RESPONSE = {
     "dossier": {
@@ -83,11 +84,11 @@ APPLICATION_DETAIL_STANDARD_RESPONSE = {
                 "value": "Étudiant",
                 "type_de_champ":
                     {
-                        "id":718094,
-                        "libelle":"Veuillez indiquer votre statut",
-                        "type_champ":"drop_down_list",
-                        "order_place":7,
-                        "description":""
+                        "id": 718094,
+                        "libelle": "Veuillez indiquer votre statut",
+                        "type_champ": "drop_down_list",
+                        "order_place": 7,
+                        "description": ""
                     }
             },
             {
@@ -262,8 +263,12 @@ APPLICATION_DETAIL_STANDARD_RESPONSE = {
 }
 
 
-def make_old_application_detail(id: int, state: str, postal_code='67200', department_code='67 - Bas-Rhin',
-                            civility='Mme', activity='Étudiant') -> dict:
+def make_old_application_detail(id: int,
+                                state: str,
+                                postal_code: str = '67200',
+                                department_code: str = '67 - Bas-Rhin',
+                                civility: str = 'Mme',
+                                activity: str = 'Étudiant') -> Dict:
     application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
     application['dossier']['id'] = id
     application['dossier']['state'] = state

--- a/tests/scripts/beneficiary/old_remote_fixture.py
+++ b/tests/scripts/beneficiary/old_remote_fixture.py
@@ -1,0 +1,278 @@
+import copy
+
+APPLICATION_DETAIL_STANDARD_RESPONSE = {
+    "dossier": {
+        "id": 123,
+        "created_at": "2019-05-04T17:57:28.726Z",
+        "updated_at": "2019-05-07T15:15:39.849Z",
+        "archived": False,
+        "email": "jane.doe@test.com",
+        "state": "closed",
+        "simplified_state": "Accepté",
+        "initiated_at": "2019-05-04T18:01:23.694Z",
+        "received_at": "2019-05-07T15:15:22.340Z",
+        "processed_at": "2019-05-07T15:15:39.393Z",
+        "motivation": "",
+        "instructeurs": ["admin.pc@example.com"],
+        "individual": {"civilite": "Mme", "nom": "Doe", "prenom": "Jane"},
+        "entreprise": None,
+        "etablissement": None, "cerfa": [], "commentaires": [
+            {
+                "email": "contact@demarches-simplifiees.fr",
+                "body": "...",
+                "created_at": "2019-05-04T18:01:24.428Z",
+                "attachment": None
+            },
+            {
+                "email": "contact@demarches-simplifiees.fr",
+                "body": "...",
+                "created_at": "2019-05-07T15:15:22.504Z",
+                "attachment": None
+            },
+            {
+                "email": "contact@demarches-simplifiees.fr",
+                "body": "...",
+                "created_at": "2019-05-07T15:15:39.845Z",
+                "attachment": None
+            }
+        ],
+        "champs_private": [],
+        "pieces_justificatives": [],
+        "types_de_piece_justificative": [],
+        "justificatif_motivation": None,
+        "champs": [
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 609447,
+                    "libelle": "Comment remplir ce formulaire de pré-inscription au pass Culture",
+                    "type_champ": "explication", "order_place": 0,
+                    "description": "Une aide pour remplir votre dossier est disponible ici : https://docs.passculture.app/experimentateurs/pre-inscription"}
+            },
+            {
+                "value": "94 - Val-de-Marne",
+                "type_de_champ": {
+                    "id": 596453, "libelle": "Veuillez indiquer votre département",
+                    "type_champ": "departements", "order_place": 1,
+                    "description": "Département de résidence (vous devrez fournir un justificatif de domicile)."
+                }
+            },
+            {
+                "value": "0123456789",
+                "type_de_champ": {
+                    "id": 582219, "libelle": "Numéro de téléphone",
+                    "type_champ": "phone", "order_place": 2, "description": ""
+                }
+            },
+            {
+                "value": "2000-05-01",
+                "type_de_champ": {
+                    "id": 582220, "libelle": "Date de naissance", "type_champ": "date",
+                    "order_place": 3,
+                    "description": "Assurez-vous de bien sélectionner votre année de naissance."
+                }
+            },
+            {
+                "value": "94200",
+                "type_de_champ": {
+                    "id": 639254, "libelle": "Code postal de votre lieu de naissance",
+                    "type_champ": "text", "order_place": 4, "description": None
+                }
+            },
+            {
+                "value": "Étudiant",
+                "type_de_champ":
+                    {
+                        "id":718094,
+                        "libelle":"Veuillez indiquer votre statut",
+                        "type_champ":"drop_down_list",
+                        "order_place":7,
+                        "description":""
+                    }
+            },
+            {
+                "value": "6 rue de la République",
+                "type_de_champ": {
+                    "id": 582223, "libelle": "Adresse de résidence",
+                    "type_champ": "address", "order_place": 5, "description": None
+                }
+            },
+            {
+                "value": "67200",
+                "type_de_champ": {
+                    "id": 582221,
+                    "libelle": "Code postal de votre adresse de résidence",
+                    "type_champ": "text", "order_place": 6,
+                    "description": None
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 582328,
+                    "libelle": "Pièces justificatives",
+                    "type_champ": "explication",
+                    "order_place": 7,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 609392, "libelle": "1. Pièce d'identité",
+                    "type_champ": "header_section", "order_place": 8,
+                    "description": None
+                }
+            },
+            {
+                "value": "http://fake.url",
+                "type_de_champ": {
+                    "id": 459819,
+                    "libelle": "Pièce d'identité (numérisation RECTO seul de votre carte d'identité ou passeport)",
+                    "type_champ": "piece_justificative", "order_place": 9,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 451284,
+                    "libelle": "2.1 Si vous avez un justificatif de domicile à votre nom :",
+                    "type_champ": "header_section", "order_place": 10,
+                    "description": ""
+                }
+            },
+            {
+                "value": "http://fake.url",
+                "type_de_champ": {
+                    "id": 422858,
+                    "libelle": "Justificatif de domicile à votre nom et prénom",
+                    "type_champ": "piece_justificative", "order_place": 11,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 460834,
+                    "libelle": "2.2 Sinon, si vous habitez chez un proche (parent, ami, etc.) :",
+                    "type_champ": "header_section", "order_place": 12,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 460835,
+                    "libelle": "Justificatif de domicile de la personne qui vous héberge",
+                    "type_champ": "piece_justificative",
+                    "order_place": 13,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 451287,
+                    "libelle": "Attestation sur l'honneur d'hébergement, datée et signée par la personne qui vous héberge et par vous-même",
+                    "type_champ": "piece_justificative",
+                    "order_place": 14,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 451288,
+                    "libelle": "Pièce d'identité de la personne qui vous héberge",
+                    "type_champ": "piece_justificative",
+                    "order_place": 15,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 460836,
+                    "libelle": "Vous n'êtes pas de nationalité française ?",
+                    "type_champ": "header_section", "order_place": 16,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 451286,
+                    "libelle": "Justificatif de présence sur le territoire français depuis plus d'un an",
+                    "type_champ": "piece_justificative",
+                    "order_place": 17,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 466695,
+                    "libelle": "Consentement à l'utilisation de mes données",
+                    "type_champ": "header_section", "order_place": 18,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+
+                "type_de_champ": {
+                    "id": 466635,
+                    "libelle": "Que faisons-nous de ces données ?",
+                    "type_champ": "explication",
+                    "order_place": 19,
+                    "description": "..."
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 466694,
+                    "libelle": "Je donne mon accord au traitement de mes données à caractère personnel dans les conditions explicitées ci-dessus",
+                    "type_champ": "engagement", "order_place": 20,
+                    "description": "..."
+                }
+            },
+            {
+                "value": "on",
+                "type_de_champ": {
+                    "id": 457303,
+                    "libelle": "Je déclare sur l’honneur que ces documents sont authentiques. ",
+                    "type_champ": "engagement",
+                    "order_place": 21,
+                    "description": "..."
+                }
+            },
+            {
+                "value": None,
+                "type_de_champ": {
+                    "id": 454775,
+                    "libelle": "Un grand merci et à très vite sur le pass Culture !",
+                    "type_champ": "header_section", "order_place": 22,
+                    "description": "..."
+                }
+            }
+        ]
+    }
+}
+
+
+def make_old_application_detail(id: int, state: str, postal_code='67200', department_code='67 - Bas-Rhin',
+                            civility='Mme', activity='Étudiant') -> dict:
+    application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
+    application['dossier']['id'] = id
+    application['dossier']['state'] = state
+    application['dossier']['individual']['civilite'] = civility
+    for field in application['dossier']['champs']:
+        if field['type_de_champ']['libelle'] == 'Veuillez indiquer votre département':
+            field['value'] = department_code
+        if field['type_de_champ']['libelle'] == 'Code postal de votre adresse de résidence':
+            field['value'] = postal_code
+        if field['type_de_champ']['libelle'] == 'Veuillez indiquer votre statut':
+            field['value'] = activity
+    return application

--- a/tests/scripts/beneficiary/old_remote_import_test.py
+++ b/tests/scripts/beneficiary/old_remote_import_test.py
@@ -113,7 +113,7 @@ class OldRemoteImportRunTest:
         beneficiary_import = BeneficiaryImport.query.first()
         assert beneficiary_import.currentStatus == ImportStatus.ERROR
         assert beneficiary_import.demarcheSimplifieeApplicationId == 123
-        assert beneficiary_import.detail == 'Le dossier 123 contient des erreurs et a été ignoré'
+        assert beneficiary_import.detail == 'Le dossier 123 contient des erreurs et a été ignoré - Procedure 2567158'
 
     @patch('scripts.beneficiary.old_remote_import.process_beneficiary_application')
     @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID': '2567158'})

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -1,0 +1,597 @@
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch, ANY
+
+from mailjet_rest import Client
+
+from models import ApiErrors, BeneficiaryImport, ImportStatus, User
+from repository import repository
+from scripts.beneficiary import remote_import
+from scripts.beneficiary.remote_import import parse_beneficiary_information
+from tests.conftest import clean_database
+from tests.model_creators.generic_creators import create_user
+from tests.scripts.beneficiary.fixture import \
+    APPLICATION_DETAIL_STANDARD_RESPONSE, make_new_beneficiary_application_details
+
+NOW = datetime.utcnow()
+DATETIME_PATTERN = '%Y-%m-%dT%H:%M:%S.%fZ'
+EIGHT_HOURS_AGO = (NOW - timedelta(hours=8)).strftime(DATETIME_PATTERN)
+FOUR_HOURS_AGO = (NOW - timedelta(hours=4)).strftime(DATETIME_PATTERN)
+TWO_DAYS_AGO = (NOW - timedelta(hours=48)).strftime(DATETIME_PATTERN)
+ONE_WEEK_AGO = NOW - timedelta(days=7)
+
+
+class RunTest:
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    def test_should_retrieve_applications_from_new_procedure_id(self, process_beneficiary_application):
+        # given
+        get_all_application_ids = Mock(return_value=[123, 456, 789])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock()
+        get_details.side_effect = [
+            make_new_beneficiary_application_details(123, 'closed'),
+            make_new_beneficiary_application_details(456, 'closed'),
+            make_new_beneficiary_application_details(789, 'closed')
+        ]
+
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=False)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        assert get_all_application_ids.call_count == 1
+        get_all_application_ids.assert_called_with(6712558, ANY, ANY)
+
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    def test_all_applications_are_processed_once(self, process_beneficiary_application):
+        # given
+        get_all_application_ids = Mock(return_value=[123, 456, 789])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock()
+        get_details.side_effect = [
+            make_new_beneficiary_application_details(123, 'closed'),
+            make_new_beneficiary_application_details(456, 'closed'),
+            make_new_beneficiary_application_details(789, 'closed')
+        ]
+
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=False)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        assert process_beneficiary_application.call_count == 3
+
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    def test_applications_to_retry_are_processed(self, process_beneficiary_application):
+        # given
+        get_all_application_ids = Mock(return_value=[123])
+        find_applications_ids_to_retry = Mock(return_value=[456, 789])
+
+        get_details = Mock()
+        get_details.side_effect = [
+            make_new_beneficiary_application_details(123, 'closed'),
+            make_new_beneficiary_application_details(456, 'closed'),
+            make_new_beneficiary_application_details(789, 'closed')
+        ]
+
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=False)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        assert process_beneficiary_application.call_count == 3
+
+    @patch('scripts.beneficiary.remote_import.parse_beneficiary_information')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_REPORT_RECIPIENTS': 'send@example.com'})
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    @clean_database
+    def test_an_error_status_is_saved_when_an_application_is_not_parsable(
+            self,
+            mocked_parse_beneficiary_information,
+            app
+    ):
+        # given
+        get_all_application_ids = Mock(return_value=[123])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock(side_effect=[make_new_beneficiary_application_details(123, 'closed')])
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=False)
+        mocked_parse_beneficiary_information.side_effect = [Exception()]
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        beneficiary_import = BeneficiaryImport.query.first()
+        assert beneficiary_import.currentStatus == ImportStatus.ERROR
+        assert beneficiary_import.demarcheSimplifieeApplicationId == 123
+        assert beneficiary_import.detail == 'Le dossier 123 contient des erreurs et a été ignoré'
+
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    def test_application_with_known_demarche_simplifiee_application_id_are_not_processed(self,
+                                                                                         process_beneficiary_application
+                                                                                         ):
+        # given
+        get_all_application_ids = Mock(return_value=[123, 456])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock(return_value=make_new_beneficiary_application_details(123, 'closed'))
+        user = User()
+        user.email = 'john.doe@example.com'
+        has_already_been_imported = Mock(return_value=True)
+        has_already_been_created = Mock(return_value=False)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        process_beneficiary_application.assert_not_called()
+
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})
+    @clean_database
+    def test_application_with_known_email_are_saved_as_rejected(self,
+                                                                process_beneficiary_application,
+                                                                app):
+        # given
+        get_all_application_ids = Mock(return_value=[123])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock(return_value=make_new_beneficiary_application_details(123, 'closed'))
+        user = User()
+        user.email = 'john.doe@example.com'
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=True)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        beneficiary_import = BeneficiaryImport.query.first()
+        assert beneficiary_import.currentStatus == ImportStatus.REJECTED
+        assert beneficiary_import.demarcheSimplifieeApplicationId == 123
+        assert beneficiary_import.detail == 'Compte existant avec cet email'
+        process_beneficiary_application.assert_not_called()
+
+    @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
+    @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '2567158'})
+    @clean_database
+    def test_beneficiary_is_created_with_procedure_id(
+            self,
+            process_beneficiary_application,
+            app
+    ):
+        # given
+        get_all_application_ids = Mock(return_value=[123])
+        find_applications_ids_to_retry = Mock(return_value=[])
+
+        get_details = Mock(side_effect=[make_new_beneficiary_application_details(123, 'closed')])
+        has_already_been_imported = Mock(return_value=False)
+        has_already_been_created = Mock(return_value=False)
+
+        # when
+        remote_import.run(
+            ONE_WEEK_AGO,
+            get_all_applications_ids=get_all_application_ids,
+            get_applications_ids_to_retry=find_applications_ids_to_retry,
+            get_details=get_details,
+            already_imported=has_already_been_imported,
+            already_existing_user=has_already_been_created
+        )
+
+        # then
+        process_beneficiary_application.assert_called_with(
+            information={
+                'last_name': 'Doe',
+                'first_name': 'John',
+                'civility': 'Mme',
+                'email': 'john.doe@test.com',
+                'application_id': 123,
+                'department': '67',
+                'phone': '0123456789',
+                'birth_date': datetime(2000, 5, 1, 0, 0),
+                'activity': 'Étudiant',
+                'postal_code': '67200'
+            },
+            error_messages=[],
+            new_beneficiaries=[],
+            retry_ids=[],
+            procedure_id=2567158
+        )
+
+
+class ProcessBeneficiaryApplicationTest:
+    @clean_database
+    def test_new_beneficiaries_are_recorded_with_deposit(self, app):
+        # given
+        app.mailjet_client = Mock(spec=Client)
+        app.mailjet_client.send = Mock()
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=[], procedure_id=123456)
+
+        # then
+        first = User.query.first()
+        assert first.email == 'jane.doe@example.com'
+        assert first.wallet_balance == 500
+        assert first.civility == 'Mme'
+        assert first.activity == 'Étudiant'
+
+    @clean_database
+    def test_an_import_status_is_saved_if_beneficiary_is_created(self, app):
+        # given
+        app.mailjet_client = Mock(spec=Client)
+        app.mailjet_client.send = Mock()
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=[], procedure_id=123456)
+
+        # then
+        beneficiary_import = BeneficiaryImport.query.first()
+        assert beneficiary_import.beneficiary.email == 'jane.doe@example.com'
+        assert beneficiary_import.currentStatus == ImportStatus.CREATED
+        assert beneficiary_import.demarcheSimplifieeApplicationId == 123
+
+    @patch('scripts.beneficiary.remote_import.create_beneficiary_from_application')
+    @patch('scripts.beneficiary.remote_import.repository')
+    @patch('scripts.beneficiary.remote_import.send_activation_email')
+    @clean_database
+    def test_account_activation_email_is_sent(self, send_activation_email, mock_repository,
+                                              create_beneficiary_from_application, app):
+        # given
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+
+        create_beneficiary_from_application.return_value = create_user()
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=[], procedure_id=123456)
+
+        # then
+        send_activation_email.assert_called()
+
+    @patch('scripts.beneficiary.remote_import.create_beneficiary_from_application')
+    @patch('scripts.beneficiary.remote_import.repository')
+    @patch('scripts.beneficiary.remote_import.send_activation_email')
+    @clean_database
+    def test_error_is_collected_if_beneficiary_could_not_be_saved(self,
+                                                                  send_activation_email, mock_repository,
+                                                                  create_beneficiary_from_application, app):
+        # given
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+        create_beneficiary_from_application.side_effect = [User()]
+        mock_repository.save.side_effect = [ApiErrors({'postalCode': ['baaaaad value']})]
+        new_beneficiaries = []
+        error_messages = []
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages, new_beneficiaries, retry_ids=[],
+                                                          procedure_id=123456)
+
+        # then
+        send_activation_email.assert_not_called()
+        assert error_messages == ['{\n  "postalCode": [\n    "baaaaad value"\n  ]\n}']
+        assert not new_beneficiaries
+
+    @patch('scripts.beneficiary.remote_import.repository')
+    @patch('scripts.beneficiary.remote_import.send_activation_email')
+    @clean_database
+    def test_beneficiary_is_not_created_if_duplicates_are_found(self, send_activation_email, mock_repository,
+                                                                app):
+        # given
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+        existing_user = create_user(date_of_birth=datetime(2000, 5, 1), first_name='Jane', last_name='Doe')
+        repository.save(existing_user)
+        mock = Mock(return_value=[existing_user])
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=[], procedure_id=123456, find_duplicate_users=mock)
+
+        # then
+        send_activation_email.assert_not_called()
+        mock_repository.save.assert_not_called()
+        beneficiary_import = BeneficiaryImport.query.filter_by(demarcheSimplifieeApplicationId=123).first()
+        assert beneficiary_import.currentStatus == ImportStatus.DUPLICATE
+
+    @patch('scripts.beneficiary.remote_import.send_activation_email')
+    @clean_database
+    def test_beneficiary_is_created_if_duplicates_are_found_but_id_is_in_retry_list(self, send_activation_email, app):
+        # given
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+        existing_user = create_user(date_of_birth=datetime(2000, 5, 1), first_name='Jane', last_name='Doe')
+        repository.save(existing_user)
+        mock = Mock(return_value=[existing_user])
+        retry_ids = [123]
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=retry_ids, procedure_id=123456,
+                                                          find_duplicate_users=mock)
+
+        # then
+        send_activation_email.assert_called()
+        beneficiary_import = BeneficiaryImport.query.filter_by(demarcheSimplifieeApplicationId=123).first()
+        assert beneficiary_import.currentStatus == ImportStatus.CREATED
+
+    @clean_database
+    def test_an_import_status_is_saved_if_beneficiary_is_a_duplicate(self, app):
+        # given
+        information = {
+            'department': '93',
+            'last_name': 'Doe',
+            'first_name': 'Jane',
+            'birth_date': datetime(2000, 5, 1),
+            'email': 'jane.doe@example.com',
+            'phone': '0612345678',
+            'postal_code': '93130',
+            'application_id': 123,
+            'civility': 'Mme',
+            'activity': 'Étudiant'
+        }
+        mocked_query = Mock(return_value=[create_user(idx=11), create_user(idx=22)])
+
+        # when
+        remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
+                                                          retry_ids=[], procedure_id=123456,
+                                                          find_duplicate_users=mocked_query)
+
+        # then
+        beneficiary_import = BeneficiaryImport.query.first()
+        assert beneficiary_import.currentStatus == ImportStatus.DUPLICATE
+        assert beneficiary_import.demarcheSimplifieeApplicationId == 123
+        assert beneficiary_import.detail == "Utilisateur en doublon : 11, 22"
+
+
+class ParseBeneficiaryInformationTest:
+    def test_personal_information_of_beneficiary_are_parsed_from_application_detail(self):
+        # when
+        information = parse_beneficiary_information(APPLICATION_DETAIL_STANDARD_RESPONSE)
+
+        # then
+        assert information['last_name'] == 'Doe'
+        assert information['first_name'] == 'John'
+        assert information['birth_date'] == datetime(2000, 5, 1)
+        assert information['civility'] == 'M.'
+        assert information['email'] == 'john.doe@test.com'
+        assert information['phone'] == '0123456789'
+        assert information['postal_code'] == '93130'
+        assert information['application_id'] == 123
+
+    def test_handles_two_digits_department_code(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', department_code='67 - Bas-Rhin')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['department'] == '67'
+
+    def test_handles_three_digits_department_code(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', department_code='973 - Guyane')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['department'] == '973'
+
+    def test_handles_uppercased_mixed_digits_and_letter_department_code(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', department_code='2B - Haute-Corse')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['department'] == '2B'
+
+    def test_handles_lowercased_mixed_digits_and_letter_department_code(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', department_code='2a - Haute-Corse')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['department'] == '2a'
+
+    def test_handles_department_code_with_another_label(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', department_code='67 - Bas-Rhin')
+        for field in application_detail['dossier']['champs']:
+            label = field['type_de_champ']['libelle']
+            if label == 'Veuillez indiquer votre département':
+                field['type_de_champ']['libelle'] = "Veuillez indiquer votre département de résidence"
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['department'] == '67'
+
+    def test_handles_postal_codes_wrapped_with_spaces(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', postal_code='  93130  ')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['postal_code'] == '93130'
+
+    def test_handles_postal_codes_containing_spaces(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', postal_code='67 200')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['postal_code'] == '67200'
+
+    def test_handles_postal_codes_containing_city_name(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', postal_code='67 200 Strasbourg ')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['postal_code'] == '67200'
+
+    def test_handles_civility_parsing(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', civility='M.')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['civility'] == 'M.'
+
+    def test_handles_activity_parsing(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed')
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['activity'] == 'Étudiant'
+
+    def test_handles_activity_even_if_activity_is_not_filled(self):
+        # given
+        application_detail = make_new_beneficiary_application_details(1, 'closed', activity=None)
+
+        # when
+        information = parse_beneficiary_information(application_detail)
+
+        # then
+        assert information['activity'] is None

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -145,7 +145,7 @@ class RunTest:
         beneficiary_import = BeneficiaryImport.query.first()
         assert beneficiary_import.currentStatus == ImportStatus.ERROR
         assert beneficiary_import.demarcheSimplifieeApplicationId == 123
-        assert beneficiary_import.detail == 'Le dossier 123 contient des erreurs et a été ignoré'
+        assert beneficiary_import.detail == 'Le dossier 123 contient des erreurs et a été ignoré - Procedure 6712558'
 
     @patch('scripts.beneficiary.remote_import.process_beneficiary_application')
     @patch.dict('os.environ', {'DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v2': '6712558'})

--- a/tests/scripts/beneficiary/remote_import_test.py
+++ b/tests/scripts/beneficiary/remote_import_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import ANY, Mock, patch
 
 from mailjet_rest import Client
 
@@ -10,7 +10,8 @@ from scripts.beneficiary.remote_import import parse_beneficiary_information
 from tests.conftest import clean_database
 from tests.model_creators.generic_creators import create_user
 from tests.scripts.beneficiary.fixture import \
-    APPLICATION_DETAIL_STANDARD_RESPONSE, make_new_beneficiary_application_details
+    APPLICATION_DETAIL_STANDARD_RESPONSE, \
+    make_new_beneficiary_application_details
 
 NOW = datetime.utcnow()
 DATETIME_PATTERN = '%Y-%m-%dT%H:%M:%S.%fZ'
@@ -275,7 +276,7 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=[], procedure_id=123456)
+                                                      retry_ids=[], procedure_id=123456)
 
         # then
         first = User.query.first()
@@ -304,7 +305,7 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=[], procedure_id=123456)
+                                                      retry_ids=[], procedure_id=123456)
 
         # then
         beneficiary_import = BeneficiaryImport.query.first()
@@ -336,7 +337,7 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=[], procedure_id=123456)
+                                                      retry_ids=[], procedure_id=123456)
 
         # then
         send_activation_email.assert_called()
@@ -368,7 +369,7 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages, new_beneficiaries, retry_ids=[],
-                                                          procedure_id=123456)
+                                                      procedure_id=123456)
 
         # then
         send_activation_email.assert_not_called()
@@ -399,7 +400,7 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=[], procedure_id=123456, find_duplicate_users=mock)
+                                                      retry_ids=[], procedure_id=123456, find_duplicate_users=mock)
 
         # then
         send_activation_email.assert_not_called()
@@ -430,8 +431,8 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=retry_ids, procedure_id=123456,
-                                                          find_duplicate_users=mock)
+                                                      retry_ids=retry_ids, procedure_id=123456,
+                                                      find_duplicate_users=mock)
 
         # then
         send_activation_email.assert_called()
@@ -457,8 +458,8 @@ class ProcessBeneficiaryApplicationTest:
 
         # when
         remote_import.process_beneficiary_application(information, error_messages=[], new_beneficiaries=[],
-                                                          retry_ids=[], procedure_id=123456,
-                                                          find_duplicate_users=mocked_query)
+                                                      retry_ids=[], procedure_id=123456,
+                                                      find_duplicate_users=mocked_query)
 
         # then
         beneficiary_import = BeneficiaryImport.query.first()


### PR DESCRIPTION
L'ancienne procédure démarche simplifiée va être remplacée au profit d'une nouvelle version de cette même procédure.

Pour simplifier la suppression de l'ancienne procédure, j'ai dupliqué le code (j'ai renommé l'original `old_remote_import`) et fait les ajustements. Il suffira de supprimer tout l'ancien code "old_*" pour s'en débarasser.

Modifications essentielles sur cette PR : 
- Chaque beneficiary_import est associé à une procédure
- On relance l'import de chaque procédure a partir du dernier import associé a cette procédure ci.
- Quelques ajustements sur le format des champs