### PR TITLE
(PC-3402): Worker app context

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,8 +4,6 @@ import os
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.rq import RqIntegration
-import redis
-from mailjet_rest import Client
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
 from admin.install import install_admin_views
@@ -16,11 +14,9 @@ from load_environment_variables import load_environment_variables
 from models.install import install_activity, install_features, install_materialized_views
 from repository.feature_queries import feature_request_profiling_enabled
 from routes import install_routes
-from utils.config import IS_DEV, REDIS_URL, ENV
+from utils.config import IS_DEV, ENV
 from utils.health_checker import read_version_from_file
-from utils.mailing import get_contact, \
-    MAILJET_API_KEY, MAILJET_API_SECRET, \
-    subscribe_newsletter
+
 
 if IS_DEV is False:
     sentry_sdk.init(
@@ -31,7 +27,8 @@ if IS_DEV is False:
     )
 
 if feature_request_profiling_enabled():
-    profiling_restrictions = [int(os.environ.get('PROFILE_REQUESTS_LINES_LIMIT', 100))]
+    profiling_restrictions = [
+        int(os.environ.get('PROFILE_REQUESTS_LINES_LIMIT', 100))]
     app.config['PROFILE'] = True
     app.wsgi_app = ProfilerMiddleware(app.wsgi_app,
                                       restrictions=profiling_restrictions)
@@ -54,12 +51,6 @@ with app.app_context():
     install_routes()
     install_documentation()
     install_admin_views(admin, db.session)
-
-    app.mailjet_client = Client(auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3')
-    app.redis_client = redis.from_url(url=REDIS_URL, decode_responses=True)
-
-    app.get_contact = get_contact
-    app.subscribe_newsletter = subscribe_newsletter
 
 if __name__ == '__main__':
     port = int(os.environ.get("PORT", 5000))

--- a/flask_app.py
+++ b/flask_app.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-from utils.mailing import get_contact, \
-    MAILJET_API_KEY, MAILJET_API_SECRET, \
-    subscribe_newsletter
+from utils.mailing import MAILJET_API_KEY, MAILJET_API_SECRET
 from utils.config import REDIS_URL
 from mailjet_rest import Client
 import redis
@@ -76,6 +74,3 @@ with app.app_context():
     app.mailjet_client = Client(
         auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3')
     app.redis_client = redis.from_url(url=REDIS_URL, decode_responses=True)
-
-    app.get_contact = get_contact
-    app.subscribe_newsletter = subscribe_newsletter

--- a/workers/decorators.py
+++ b/workers/decorators.py
@@ -7,20 +7,13 @@ from sqlalchemy import orm
 from functools import wraps
 from utils.logger import logger
 from workers.logger import build_job_log_message, JobStatus
-
-
-app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db.init_app(app)
-orm.configure_mappers()
+from flask_app import app
 
 
 def job_context(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        worker_application = app
-        with worker_application.app_context():
+        with app.app_context():
             return func(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
Problème : 
Le process `worker.py` tourne avec un `app.app_context()` qui ne possède pas la config mailjet

Solution : 
Faire en sorte que ce process tourne avec un app le plus proche possible du process principal `app.py` (avec notament la config mailjet)

Implémentation : 
Malheureusement l'objet app de `app.py` ne peut pas être utilisé directement à cause d'import circulaire
La solution est d'importer l'objet app de `flask_app.py` qui comprend déjà une partie de la configuration, et d'y déplacer la configuration manquante et nécéssaire à worker.py