### PR TITLE
(PC-4118): Fix thumb for offer

### DIFF
--- a/algolia/infrastructure/builder.py
+++ b/algolia/infrastructure/builder.py
@@ -67,7 +67,7 @@ def build_object(offer: OfferSQLEntity) -> Dict:
             'speaker': speaker,
             'stageDirector': stage_director,
             'stocksDateCreated': sorted(stocks_date_created),
-            'thumbUrl': offer.thumb_url,
+            'thumbUrl': offer.thumbUrl,
             'tags': tags,
             'times': list(set(times)),
             'type': offer.offerType['sublabel'],

--- a/domain/favorite/favorite.py
+++ b/domain/favorite/favorite.py
@@ -19,4 +19,4 @@ class Favorite(object):
     def thumb_url(self) -> str:
         if self.mediation:
             return self.mediation.thumbUrl
-        return self.offer.thumb_url
+        return self.offer.thumbUrl

--- a/models/offer_sql_entity.py
+++ b/models/offer_sql_entity.py
@@ -224,7 +224,7 @@ class OfferSQLEntity(PcObject,
                f" {pluralize(stocks_remaining_quantity, 'restant')}"
 
     @property
-    def thumb_url(self) -> str:
+    def thumbUrl(self) -> str:
         offer_has_active_mediation = any(map(lambda mediation: mediation.isActive, self.mediations))
         if offer_has_active_mediation:
             return self.activeMediation.thumbUrl

--- a/tests/models/offer_sql_entity_test.py
+++ b/tests/models/offer_sql_entity_test.py
@@ -873,7 +873,7 @@ class ThumbUrlTest:
         offer.mediations = [create_mediation(idx=1, date_created=datetime(2019, 11, 1, 10, 0, 0), thumb_count=1)]
 
         # then
-        assert offer.thumb_url == 'http://localhost/storage/thumbs/mediations/AE'
+        assert offer.thumbUrl == 'http://localhost/storage/thumbs/mediations/AE'
 
     def test_should_return_thumb_url_with_product_when_mediation_does_not_exist(self):
         # given
@@ -882,14 +882,14 @@ class ThumbUrlTest:
         offer.product.id = 1
 
         # then
-        assert offer.thumb_url == 'http://localhost/storage/thumbs/products/AE'
+        assert offer.thumbUrl == 'http://localhost/storage/thumbs/products/AE'
 
     def test_should_return_empty_thumb_url_when_no_product_nor_mediation(self):
         # given
         offer = OfferSQLEntity()
 
         # then
-        assert offer.thumb_url == ''
+        assert offer.thumbUrl == ''
 
 
 class OfferTypeTest:

--- a/tests/routes/get_offer_test.py
+++ b/tests/routes/get_offer_test.py
@@ -35,7 +35,7 @@ class Get:
             assert 'iban' in response_json['venue']['managingOfferer']
             assert 'bic' in response_json['venue']['managingOfferer']
             assert 'validationToken' not in response_json['venue']['managingOfferer']
-            assert 'thumb_url' in response_json
+            assert 'thumbUrl' in response_json
 
         @clean_database
         def when_returns_an_active_mediation(self, app):

--- a/utils/includes.py
+++ b/utils/includes.py
@@ -45,7 +45,7 @@ OFFER_INCLUDES = [
     "lastProvider",
     "offerType",
     "availabilityMessage",
-    "thumb_url",
+    "thumbUrl",
     {
         "key": "activeMediation",
         "includes": ["thumbUrl"]
@@ -105,6 +105,7 @@ RECOMMENDATION_INCLUDES = [
             'isFullyBooked',
             "isThing",
             "offerType",
+            "thumbUrl",
             {
                 "key": "product",
                 "includes": ["thumbUrl"]
@@ -155,7 +156,7 @@ WEBAPP_GET_BOOKING_INCLUDES = [
             {
                 "key": "offer",
                 "includes": [
-                    'thumb_url',
+                    'thumbUrl',
                     'hasBookingLimitDatetimesPassed',
                     'isBookable',
                     'isDigital',
@@ -204,6 +205,7 @@ WEBAPP_PATCH_POST_BOOKING_INCLUDES = [
                     "isFullyBooked",
                     "isThing",
                     "offerType",
+                    "thumbUrl",
                     {
                         "key": "product",
                         "includes": ["thumbUrl"]


### PR DESCRIPTION
Renommer thumb_url de offer en thumbUrl pour être cohérent avec le nommage front et ne pas avoir a modifier le code de la webapp existant.